### PR TITLE
Testing the Renderer's Backwards Compatibility

### DIFF
--- a/examples/pixel_renderer/create_sample_images.py
+++ b/examples/pixel_renderer/create_sample_images.py
@@ -1,0 +1,155 @@
+import argparse
+import csv
+import json
+import os
+import shutil
+import sys
+from importlib import metadata
+
+from PIL import Image
+
+from font_download import FontConfig
+from font_download.example_fonts.noto_sans import FONTS_NOTO_SANS
+from pixel_renderer import PixelRendererProcessor
+
+
+def read_tsv(input_file):
+    """Read TSV file into a list of dicts."""
+    with open(input_file, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        return list(reader)
+
+
+def group_by_language(rows):
+    """Group rows by language key."""
+    grouped = {}
+    for row in rows:
+        lang = row["language"]
+        grouped.setdefault(lang, []).append(row)
+    return grouped
+
+
+def create_language_image(lang, examples, pixel_processor, output_dir):
+    """Render and concatenate text images for one language."""
+    examples_sorted = sorted(examples, key=lambda x: int(x["index_id"]))
+
+    rendered_images = []
+    for ex in examples_sorted:
+        text = ex.get("text", "").strip()
+        if not text:
+            continue
+        img = pixel_processor.render_text_image(text)
+        rendered_images.append(img)
+
+    if not rendered_images:
+        print(f"⚠️ No text rendered for {lang}")
+        return
+
+    widths = [im.width for im in rendered_images]
+    heights = [im.height for im in rendered_images]
+    total_height = sum(heights)
+    max_width = max(widths)
+
+    combined = Image.new("RGBA", (max_width, total_height), (255, 255, 255, 0))
+    y_offset = 0
+    for im in rendered_images:
+        combined.paste(im, (0, y_offset))
+        y_offset += im.height
+
+    output_path = os.path.join(output_dir, f"{lang}.png")
+    combined.save(output_path)
+    print(f"✅ Saved {output_path}")
+
+
+def get_versions():
+    """Collect versions of relevant packages."""
+    pkgs = [
+        "pycairo",
+        "pango",
+        "cairo",
+        "manimpango",
+        "pixel_renderer",
+        "pygobject",
+        "gi",  # newly added
+    ]
+    versions = {}
+
+    # Python package versions
+    for pkg in pkgs:
+        try:
+            versions[pkg] = metadata.version(pkg)
+        except metadata.PackageNotFoundError:
+            versions[pkg] = None
+
+    # Try native version lookups
+    try:
+        import cairo
+
+        if hasattr(cairo, "cairo_version_string"):
+            versions["cairo"] = cairo.cairo_version_string()
+        elif hasattr(cairo, "version"):
+            versions["cairo"] = cairo.version
+    except ImportError:
+        pass
+
+    try:
+        from gi.repository import Pango
+
+        if hasattr(Pango, "version_string"):
+            versions["pango"] = Pango.version_string()
+    except ImportError:
+        pass
+
+    try:
+        import gi
+
+        if hasattr(gi, "__version__"):
+            versions["gi"] = gi.__version__
+    except ImportError:
+        pass
+
+    return versions
+
+
+def write_versions_json(output_dir):
+    versions = get_versions()
+    version_path = os.path.join(output_dir, "versions.json")
+    with open(version_path, "w", encoding="utf-8") as f:
+        json.dump(versions, f, indent=2)
+    print(f"📦 Saved version info to {version_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render grouped text images by language using PixelRenderer.")
+    parser.add_argument("--input-file", required=True, help="Path to the TSV input file.")
+    parser.add_argument("--output-dir", required=True, help="Directory to save output images.")
+    args = parser.parse_args()
+
+    # Validate output directory
+    if os.path.exists(args.output_dir):
+        print(f"❌ Error: Output directory '{args.output_dir}' already exists. Aborting.")
+        sys.exit(1)
+
+    os.makedirs(args.output_dir, exist_ok=False)
+    shutil.copy2(args.input_file, os.path.join(args.output_dir, os.path.basename(args.input_file)))
+
+    # Load TSV and group by language
+    rows = read_tsv(args.input_file)
+    grouped = group_by_language(rows)
+
+    # Initialize renderer
+    font_config = FontConfig(sources=FONTS_NOTO_SANS)
+    pixel_processor = PixelRendererProcessor(font=font_config)
+
+    # Render each language
+    for lang, examples in grouped.items():
+        create_language_image(lang, examples, pixel_processor, args.output_dir)
+
+    # Record library versions
+    write_versions_json(args.output_dir)
+
+    print(f"\n🎉 All done! Images and metadata saved in '{args.output_dir}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pixel_renderer/samples.tsv
+++ b/examples/pixel_renderer/samples.tsv
@@ -1,0 +1,1026 @@
+index_id	category	text	language
+548	sports	دڠن ماوبه نيبك سڤرڤت او سيتڠوه ميل جيڤلوڠ, اوكور ك باݢه ڤلوڠ جد ك لبيه هنا ڤنتيڠ ڠن تناݢ جد ك حل ڽڠ ك كبوتوهن.	ace_Arab
+824	travel	كالن بك ڤو ڽڠ ݢڤتب لي اݢين, ڤو ڽڠ نا بك ويبسيت اتوا بك تيڠكڤ توكو.	ace_Arab
+1628	geography	جومله اورڠ ڽڠ تيڠݢل بك كوتا فاكيتن ڽنكه كورڠ لبيه ٨٠٠. ڽنكه نڠݢري مردهكا ڽڠ ڤاليڠ اوبيت د دونيا ڠن نڠݢري ڽڠ ڤاليڠ ديت اورڠ تيڠݢل.	ace_Arab
+1596	science/technology	اوجي چوبا هيرسهي ڠن چهيسى ناكه ساله سابوه ڤنداڤت مشهور د ن أ ڽن ناكه سابوه ماتري ݢينيتيك.	ace_Arab
+739	geography	ڤولو چووق ڽنكه ڤولو ڽڠ مساڤت ببس ڠن سلنديا بارو, نا د ڤوليسينيا, بك تڠوه تڠوه بله تونوڠ سامودرا ڤاسيفيك.	ace_Arab
+548	sports	Dengön meuubah nibak siperpeut u siteungoh mil jiplueng, ukoe keu bagah plueng jeuet keu leubѐh hana peunteng ngön teunaga jeuet keu hai nyang keu kebutuhan.	ace_Latn
+824	travel	Kalon bak peu nyang geupeutaba le agen, peu nyang na bak website atawa bak tingkap toko.	ace_Latn
+1628	geography	Jumlah ureueng nyang tinggai bak Kuta Vatikan nyankeuh kureueng leubѐh 800. Nyankeuh nanggroe meurdehka nyang paleng ubeut i donya ngön nanggroe nyang paleng dit ureueng tinggai.	ace_Latn
+1596	science/technology	Ujoecuba Hershey ngön Chase nakeuh salah saboh peundapat meuceuhu DNA nyan nakeuh saboh materi genetik.	ace_Latn
+739	geography	Pulo Cook nyankeuh pulo nyang meusapat bebah ngoen Selandia Baro, na i Polysinia, bak teungoh-teungoh blah Tunong Samudra Pasifik.	ace_Latn
+548	sports	مع التغيير بمسافة السباق من 400 متر إلى 800 متر تصير السرعة أقل أهمية بهواية وتصير القدرة على التحمل ضرورة مطلقة.	acm_Arab
+824	travel	أخذ نظرة على  الرحلات اللي يسويلها الوكيل دعاية، سواء كان هالشي على موقع إلكتروني أو على شباك محل.	acm_Arab
+1628	geography	يبلغ عدد سكان مدينة الفاتيكان حوالي ٨٠٠. وهي أصغر دولة مستقلة بالعالم وأقل تعداد سكانيِ.	acm_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس وحدة من الدلائل الرئيسية على أن الحمض النووي مادة وراثية.	acm_Arab
+739	geography	جزر كوك هي دولة جزرية مرتبطة بشكل حر بنيوزيلندا، وتصير ببولينيزيا وسط جنوب المحيط الهادئ.	acm_Arab
+548	sports	مع التغيير بمسافة السباق من ربع ميل إلى نُص ميل ترجع السرعة مش مهمة وترجع القدرة على التحمل ضرورية جداً.	acq_Arab
+824	travel	اعمل نظرة على الرحلات اللي يقوم الوكيل بترويجها، سواءً كان ذلك على موقع إلكتروني أو في نافذة متجر.	acq_Arab
+1628	geography	يصل عدد سكان مدينة الفاتيكان حوالي ٨٠٠. وهي أصغر دولة مستقلة بالعالم وأقل تعدادٍ سكانيِّ.	acq_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس واحدة من الدلائل الرئيسية على أن الحمض النووي مادة وراثية.	acq_Arab
+739	geography	جزر كوك هي دولة جزرية مرتبطة بشكل حر بنيوزيلندا، وتقع في بولينيزيا وسط جنوب المحيط الهادئ.	acq_Arab
+548	sports	مع التغيير في مسافة السباق من ربع ميل لنُص ميل تولي السرعة أقل أهمية ببرشا وتولي القدرة على التحمل مهمة ياسر.	aeb_Arab
+824	travel	أعمل طلة على الرحلات الي يخدمها الوكيل، اما على السيت واب والا في الكيشي.	aeb_Arab
+1628	geography	يبلغ عدد سكان مدينة الفاتيكان حوالي 800. وهي أصغر دولة مستقلة في العالم وأقل تعدادٍ سكانيِّ.	aeb_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس واحدة من الدلائل الرئيسية على أن الحمض النووي مادة وراثية.	aeb_Arab
+739	geography	جزر كوك هي دولة كلها جزر مرتبطة بشكل حر بنيوزيلندا، وموجودة في بولينيزيا وسط جنوب المحيط الهادئ.	aeb_Arab
+548	sports	Met die verandering van die kwart na die halfmyl wedloop, word spoed minder belangrik, en uithou vermoë word ‘n absolute noodsaaklikheid.	afr_Latn
+824	travel	Kyk na watter reise die agent bevorder, of op ‘n webtuiste of in a winkelvenster.	afr_Latn
+1628	geography	Die Vatikaanstad se bevolking is ongeveer 800. Dis die kleinste onafhanklike land in die wêreld en die land met die laagste bevolking.	afr_Latn
+1596	science/technology	Die Hershey en Chase eksperiment was een van die hoofvoorstelle dat DNA genetiese materiaal is.	afr_Latn
+739	geography	Die Cook Eilande is 'n eiland land in vrye assosiasie met Nieu-Seeland, gevind in Polinesië, in die middel van die Suid-Pasifiese Oseaan.	afr_Latn
+548	sports	مع التغيير من ربع ميل إلى نصف ميل ، بتصير السرعة أقل أهمية بكثير وبيصير التحمل ضرورة مطلقة.	ajp_Arab
+824	travel	خودلك نظرة على الرحلات اللي بروج إلها الوكيل ، سواء على موقع ويب أو في شباك محل.	ajp_Arab
+1628	geography	عدد سكان مدينة الفاتيكان حوالي 800. وهيه أصغر دولة مستقلة بالعالم وأقل عدد سكان.	ajp_Arab
+1596	science/technology	تجربة هيرشي وتشيس كانت وحدة من الدلائل الرئيسية على انه الحمض النووي كان مادة وراثية.	ajp_Arab
+739	geography	جزر كوك هيه دولة على جزيرة بارتباط حر مع نيوزيلندا ، وموجودة في بولينيزيا ، بوسط جنوب المحيط الهادي.	ajp_Arab
+548	sports	Esiane sɛ wɔasesa mmirikatuo no firi anan mu nkyekyemu baako kɔ ɛfa no nti, ama ahohyɛsoɔ hu abehia sene ahoɔhare.	aka_Latn
+824	travel	Hwԑ akwantuo a ɔrebɔ ho dawuro no, wɔ wԑbsate so anaa wɔ ‘shop window’ so.	aka_Latn
+1628	geography	Vatican City mu nnipa dodoɔ yɛ ahannwɔtwe. Ɛyɛ ɔman ketewa a adi ne ho wɔ wiase yi mu ne ɔman a emu nnipa sua.	aka_Latn
+1596	science/technology	Hershey ne Chase nhwehwɛmu no yɛ adwenkyerɛ a edi mu no mu baako a ɛka sɛ DNA no yɛ biribi a ɛkora yɛn nipadua ho nsɛm so.	aka_Latn
+739	geography	Cook nsuopɔ no yɛ nsuopɔ ɔman a ɛne New Zealand bɔ fekuo, ɛwɔ Polynesia, wɔ Anaafoɔfam Pacific Ɛpo no mfinimfini.	aka_Latn
+548	sports	Në garat 800-metërshe, shpejtësia ka shumë më pak rëndësi sesa në ato 400-metërshe dhe rezistenca bëhet nevojë absolute.	als_Latn
+824	travel	Hidhni një sy se cilat udhëtime po reklamon agjenti, qoftë në një sajt uebi apo në një vitrinë dyqani.	als_Latn
+1628	geography	Popullsia e Vatikanit është afërsisht 800. Ai është shteti më i vogël i pavarur në botë dhe shteti me popullsi më të vogël.	als_Latn
+1596	science/technology	Eksperimenti nga Hershey dhe Chase ishte një nga propozimet kryesore se ADN-ja ishte një material gjenetik.	als_Latn
+739	geography	Ishujt Kuk që ndodhen në Polinezi, në mes të Oqeanit Paqësor Jugor, janë vend ishullor në lidhje të lirë me Zelandën e Re.	als_Latn
+548	sports	ከሩብ ወደ ግማሽ ማይል ሩጫ ባለው ለውጥ ፣ ፍጥነት በጣም ያነሰ ጠቀሜታ ያለው እና ጽናት ፍጹም አስፈላጊ ይሆናል።	amh_Ethi
+824	travel	ወኪሉ ፣ በድረገፅ ወይም በሱቅ መስኮት ላይ፣ ምን አይነት ጉዞዎችን እንደሚያስተዋውቅ ተመልከት።	amh_Ethi
+1628	geography	የቫቲካን ሲቲ ህዝብ ቁጥር ወደ 800 ገደማ ነው። በዓለም ትንሹ ሉዓላዊ ሃገር እና ትንሹ የህዝብ ቁጥር ያለው ሃገር ነው።	amh_Ethi
+1596	science/technology	የሄርሽ እና ቼስ ሙከራ ዲኤንኤ የጄኔቲክ ቁሳቁስ ነበር ከሚለው መሪ ሃሳብ መካከል አንዱ ነበር።	amh_Ethi
+739	geography	The Cook Islands የደሴት ሀገር ስትሆን ከኒውዚላንድ ጋር ነፃ የሆነ ግንኙነት ሲኖራት በመሀል የደቡባዊ ፓስፊክ ውቅያኖስ፣ Polynesia አካባቢ ትገኛለች።	amh_Ethi
+548	sports	مع التغيير من ربع ميل لنص ميل، بتصير السرعة أقل أهمية وبصير التحمل ضرورة أساسية.	apc_Arab
+824	travel	ألق نظرة على الرحلات يلّي عم بروج لها الوكيل، إن كان على موقع ويب أو من شبابيك المحلات.	apc_Arab
+1628	geography	يبلغ عدد سكان مدينة الفاتيكان حوالي 800. وهي أصغر دولة مستقلة بالعالم بأقل عدد من السكان.	apc_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس وحدة من الاقتراحات الرئيسية بأن الحمض النووي مادة وراثية.	apc_Arab
+739	geography	جزر كوك دولة جزرية بارتباط حر مع نيوزيلندا، وتقع ببولينيزيا، بنص جنوب المحيط الهادئ.	apc_Arab
+548	sports	مع التغيير في مسافة السباق من ربع ميل إلى نصف ميل تُصبح السرعة أقل أهمية بكثير وتصبح القدرة على التحمل ضرورة مطلقة.	arb_Arab
+824	travel	ألقِ نظرة على الرحلات التي يقوم الوكيل بترويجها، سواءً كان ذلك على موقع إلكتروني أو في نافذة متجر.	arb_Arab
+1628	geography	يبلغ عدد سكان مدينة الفاتيكان حوالي ٨٠٠. وهي أصغر دولة مستقلة في العالم وأقل تعدادٍ سكانيِّ.	arb_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس واحدة من الدلائل الرئيسية على أن الحمض النووي مادة وراثية.	arb_Arab
+739	geography	جزر كوك هي دولة جزرية مرتبطة بشكل حر بنيوزيلندا، وتقع في بولينيزيا وسط جنوب المحيط الهادئ.	arb_Arab
+548	sports	Ma3a 7uduth attaghyir min rub3 mil ila nisf mil, tusbi7 assur3a aqal ahamiya bi kathir wa yusbi7 atta7amul darura quswa.	arb_Latn
+824	travel	Alqi nadhra 3ala arra7alat allaty yurawwiju laha al-wakil, sawa2 3ala mawqi3 web aw fi wajihat matjar.	arb_Latn
+1628	geography	Yablugh 3adad sukـkan madinat al-Vatican na7wa 800 nasama. Fa hiya asghar dawla mustaqila fil 3alam wa al-aqal fi 3adad assukan.	arb_Latn
+1596	science/technology	2u3tubirat tajribet Hershey wa Chase wa7ida mina alfradhiyat arra2isiـya allaty tufidu bi 2anna al7imdh annawawy madda wirathiya.	arb_Latn
+739	geography	Juzur Cook hiya dawla tatakawwan min 3iddat juzur laha irtibat 7ur ma3a New Zelanda, wa taqa3u fi Polynesia bi-wasat janub al-mu7it al-hadi2.	arb_Latn
+548	sports	مع التغيير في مسافة السباق من ربع ميل إلى نصف ميل تُصبح السرعة أقل أهمية بكثير وتصبح القدرة على التحمل ضرورة مطلقة.	ars_Arab
+824	travel	ألقِ نظرة على الرحلات التي يقوم الوكيل بترويجها، سواءً كان ذلك على موقع إلكتروني أو في نافذة متجر.	ars_Arab
+1628	geography	يبلغ عدد سكان مدينة الفاتيكان حوالي ٨٠٠. وهي أصغر دولة مستقلة في العالم وأقل تعدادٍ سكانيِّ.	ars_Arab
+1596	science/technology	كانت تجربة هيرشي وتشيس واحدة من الدلائل الرئيسية على أن الحمض النووي مادة وراثية.	ars_Arab
+739	geography	جزر كوك هي دولة جزرية مرتبطة بشكل حر بنيوزيلندا، وتقع في بولينيزيا وسط جنوب المحيط الهادئ.	ars_Arab
+548	sports	فاش كتبدل من ربع لنص ميل، مكتبقاش السرعة مهمة وكتولي قدرة التحمل شي حاجة ضرورية.	ary_Arab
+824	travel	شوف الرحلات التي كيروج لها الوكيل، سواء فالموقع ويب ولا فالمحل.	ary_Arab
+1628	geography	مدينتْ الفاتيكان فيها تقريبا شي تمان ميا (800) واحد، و هي أصغر مدينا مستقله فالعالم و لي فيها أقل عدد ديال السكان.	ary_Arab
+1596	science/technology	التجربة نتاع هيرشي وشيز كانت من بين لقتراحات أن لادي إن مادة جينية.	ary_Arab
+739	geography	جزر كوك هي دولة من جزر متابطين بشكل حر مع نيوزيلندا، وكاينة في بولينيزيا، في وسط جنوب المحيط الهادئ.	ary_Arab
+548	sports	لما نغير المسافة من ربع ميل إلى نص ميل، السرعة بقت أقل أهمية بكتير وبقت القدرة على التحمل أمر ضروري مفيش مفر منه.	arz_Arab
+824	travel	بص على الرحلات اللي بيقوم الوكيل بترويجه ونشرها، سواء كان ذلك على موقع إلكتروني أو في نافذة متجر.	arz_Arab
+1628	geography	عدد سكان مدينة الفاتيكان حوالي 800 شخص. وهي أصغر بلد مستقلة في الدنيا كلها والأقل في عدد السكان.	arz_Arab
+1596	science/technology	تجربة هيرشي و تشيس كانت واحدة من الأدلة المهمة على أن الحمض النووي هو مادة وراثية.	arz_Arab
+739	geography	جزر كوك دي دولة جزرية بترتبط ارتباط حر بنيوزيلندا، وموجودة في بولينيزيا في وسط جنوب المحيط الهادئ.	arz_Arab
+548	sports	চতুৰ্থাংশৰ পৰা আধা মাইল দৌৰত পৰিৱৰ্তনটোৰ সৈতে, গতি বহুত কম গুৰুত্বপূৰ্ণ হৈ যায় আৰু সহনশীলতা এক পৰম অপৰিহাৰ্য হৈ যায়৷	asm_Beng
+824	travel	যিটো যাত্ৰাৰ প্ৰসংশা প্ৰতিনিধিগৰাকীয়ে কৰি আছে সেইটো এবাৰ চাই লোৱা, সেইটো ৱেবছাইটত আছে নে বিপণীত আছে।	asm_Beng
+1628	geography	ভেটিকান চিটিৰ জনসংখ্যা প্ৰায় ৮০০। এইখন হৈছে বিশ্বৰ আটাইতকৈ সৰু দেশ আৰু বিশ্বৰ ভিতৰতে আটাইতকৈ কম জনসংখ্যা থকা এখন দেশ।	asm_Beng
+1596	science/technology	হাৰ্ছি আৰু চে'জৰ সম্পৰীক্ষা, DNS এটা বংশনিৰ্ণায়ক উপাদান তত্বটোৰ অন্যতম দিশ নিৰ্দেশক আছিল।	asm_Beng
+739	geography	কুক দ্বীপপুঞ্জ হ'ল নিউজিলেণ্ডৰ সৈতে মুক্ত সম্পৰ্ক থকা এখন দ্বীপ ৰাষ্ট্ৰ, এইখন দক্ষিণ প্ৰশান্ত মহাগৰৰ মধ্যভাগৰ পলিনেচিয়াত অৱস্থিত।	asm_Beng
+548	sports	Col cambéu del cuartu de milla pa la media milla, la velocidá faise muncho menos importante y la resistencia ye primordial.	ast_Latn
+824	travel	Mira pa lo qu’ufre l’axencia, bien nun sitiu web o nun escaparate.	ast_Latn
+1628	geography	La población de Ciudá del Vaticanu ta polos 800 habitantes. Ye’l país independiente más pequeñu del mundu y el país cola menor población.	ast_Latn
+1596	science/technology	L'esperimentu de Hershey y Chase foi concluyente pa determinar que l'ADN yera material xenético.	ast_Latn
+739	geography	Les islles Cook son un archipiélagu, asitiáu na Polinesia, na metá del pacíficu sur, que ta en llibre asociación con Nueva Zelanda.	ast_Latn
+548	sports	दौड़ का दौरान दौड़ की गति मा बदलाव करय से चौथाई से आधा मील की दौड़ का बाद गति का महत्व कम होई जात है। इस दौरन सयंम बनाए रखब सबसे ज़रूरी होत है।	awa_Deva
+824	travel	एक नज़र डाल लें कि एजेंट कऊन यात्रा का प्रचार करत अहै, चाहे ऊ वेबसाइट पर होए या दुकान पर।	awa_Deva
+1628	geography	वेटिकन सिटी का आबादी करीब 800 है। दुनिया क सबसे छोट, स्वतंत्र अऊर सबसे कम जनसंख्या वाला देश है।	awa_Deva
+1596	science/technology	हर्शे अऊर चेज़  प्रयोग का प्रमुख सुझावन मा से एक इ रहा कि डीएनए एक आनुवंशिक सामग्री है।	awa_Deva
+739	geography	कुक आइलैंड्स दक्षिण प्रशांत महासागर के मध्य मा, पोलिनेशिया मा स्थित न्यूजीलैंड का साथ मुक्त सहयोग मा एक द्वीप देश अहै।	awa_Deva
+548	sports	Atipt'äw mä milla chikatan chikatapat jalañ chika milla jalañatak mayjt'ayasax, jank'achasiñax janiw sint wakisxiti, jan qhipartañaw juk'ampis munasxaraki.	ayr_Latn
+824	travel	Irnaqirin ch'usasiwitak juk'a chaninik uñt'ayki ukanak uñjt'am, ukax llikan jan ukax wintanan apkatataspawa.	ayr_Latn
+1628	geography	Vaticano markanx 800 markachiriw utjasi. Uraqpachanx wali jisk'a marka uñt'ataw ukhamarak juk'a jaqin marka uñt'atarakiwa.	ayr_Latn
+1596	science/technology	Hershey ukat Chase yant'ax nayrïr p'iqiñchir DNA jathatuqix yatxatatanakataynawa.	ayr_Latn
+739	geography	Cook Wat'a Markanx walja wat'aw utji, Nueva Zelandamp mayacht'asiñ amtawiyapxi, Polinesia uraqinkiwa, kupituq Pacífico Lamar Quta taypina.	ayr_Latn
+548	sports	یک چهارم مایل یرنه یارم مایل قاشماقنان سرعتن اهمیتی چوخ آزالر و استقامت بیر مطلق ضرورت اولور.	azb_Arab
+824	travel	او مسافرتلره کی آژانس وبسایتندا یا توکانن ویترینیننده اولاری ترویج ورر باخن.	azb_Arab
+1628	geography	واتیکان شهرین جمعیتی تقریبا 800 نفر دی. او لاپ چیچیه مستقل مملکت و لاپ آز جمعیتی اولان مملکت دنیادادی .	azb_Arab
+1596	science/technology	هرشی نن چیسن آزمایشی اصلی اشاره لرین بیری دی ان ای این ژنتیکی ماده ائلماقنیدی.	azb_Arab
+739	geography	کوک جزیره لری بیر جزیره مملکت دیلر کی نیوزیلندنن کی پلی نزی ده قرار تاپپ و اقیانوس آرامن آراسندادی، آزاد ارتباطلاری وار.	azb_Arab
+548	sports	Dörddə bir mil məsafəyə qaçışdan yarım mil məsafə qaçışına keçərkən sürətin əhəmiyyəti qat-qat azalır, bunun əvəzinə dözümlülük isə mütləq bir zərurətə çevrilir.	azj_Latn
+824	travel	İstər veb-saytda, istərsə də mağaza vitrinində, agentliyin nə kimi səyahətləri reklam etdiyinə göz gəzdirin.	azj_Latn
+1628	geography	Vatikanın təxminən 800 nəfər sakini var. O, dünyada ən kiçik, müstəqil və əhalisinin sayı ən az olan ölkə hesab olunur.	azj_Latn
+1596	science/technology	DNT-nin genetik bir material olduğu Herşi və Çeyzin təcrübəsinə əsasən irəli sürülən əsas fikirlərdən biri idi.	azj_Latn
+739	geography	Kuk adaları, Polineziyada yerləşən Yeni Zelandiya ilə sərbəst əməkdaşlığa sahib və Sakit okeanın cənub hissəsinin mərkəzində olan bir ada ölkəsidir.	azj_Latn
+548	sports	Сирек милдән ярты милгә күскәс, тиҙлектең әһәмиәте кәмей һәм сыҙамлыҡ иң кәрәк нәмәгә әйләнә.	bak_Cyrl
+824	travel	Ҡарағыҙ, агент, веб-сайтта булһынмы ул йәки магазин витринаһындамы, ниндәй сәфәрҙәрҙе алға һөрә.	bak_Cyrl
+1628	geography	Ватикан ҡалаһындағы кешеләр һаны яҡынса 800. Ул донъялағы иң бәләкәй үҙ аллы дәүләт һәм халыҡ һаны иң аҙ булған ил тип һанала.	bak_Cyrl
+1596	science/technology	Херши һәм Чейздың тикшеренеүе ДНК-ның генетик материал булыуын иҫбат итеүсе төп фараздарҙың береһе була.	bak_Cyrl
+739	geography	Кук утрауҙары – Тымыҡ океандың көньяғында, Полинезияла урынлашҡан, Яңы Зеландия менән ирекле бәйләнештәге утрау дәүләте.	bak_Cyrl
+548	sports	Nin yɛlɛmali ye kimotɛri tilan ko naani na bolila, teliya be dɔgɔyala baakɛ ani jijali kɛra jagoya ye.	bam_Latn
+824	travel	A lajɛ woyasi ɲɛnɛbɔba baarakɛla beka min purosiyɔn kɛ, nin siti dɔ sanfɛlala walima butiki dɔ finɛtiri la.	bam_Latn
+1628	geography	Vatican Dugu mɔgɔ ye 800 bɔɲɔgɔngo ye. A lele jamana fitini min ka yɛrɛmahɔrɔnya ba bolo diɲɛ kɔnɔ ani jamana nin mɔgɔ hakɛya ka dɔgɔ ka tɛmɛ.	bam_Latn
+1596	science/technology	Hershey ani Chase ka sɛgɛsɛgɛli kun ye hakilina ɲɛfɛ ta ya nin adayɛni kun ye a jɔlan fɛn ye.	bam_Latn
+739	geography	Cook Islands ye gun jamana ye min tugulen yɛrɛmahɔrɔnyala Nouvelle Zelande la, be Polynesie, Ocean Pacific worodugu yanfan camancɛla.	bam_Latn
+548	sports	Antuk paubahan saking seperempat ngantos atenga mil pamargi, kecepatan dados doh lebih mabuat tur daya tahan dados dahat kasaratang.	ban_Latn
+824	travel	Cingakin napi sane kapromosiang olih agen, ring situs web utawi ring jendela tokone.	ban_Latn
+1628	geography	Populasi Kota Vatikan wantah sawatara 800. Punika wantah negara bebas pinih alit ring jagate tur negara sane madue populasi pinih akidik.	ban_Latn
+1596	science/technology	Eksperimen Hershey miwah Chase wantah silih sinunggil papineh sane subaga antuk DNA wantah materi genetik.	ban_Latn
+739	geography	Kepuloan Cook Inggih punika negara pulo sane madue hubungan bebas marep ring Selandia Baru, magenah ring Polinesia, ring tengah Segara Pasifik Kelod.	ban_Latn
+548	sports	Пры пераходзе ад дыстанцыі ў чвэрць мілі да паловы мілі хуткасць страчвае сваю важнасць, затое абсалютнай неабходнасцю становіцца трываласць.	bel_Cyrl
+824	travel	Азнаёмцеся з падарожжамі, якія прапаноўвае агент — альбо на вэб-сайце, альбо ў офісе.	bel_Cyrl
+1628	geography	У Ватыкане пражывае ўсяго каля 800 чалавек. Гэта самая маленькая ў свеце незалежная краіна з найменшай колькасцю насельніцтва.	bel_Cyrl
+1596	science/technology	Адна з асноўных гіпотэз, якая сцвярджала, што ДНК з'яўляецца генетычным матэрыялам, была праверана ў ходзе эксперыменту Хершы і Чэйза.	bel_Cyrl
+739	geography	Астравы Кука — гэта астраўная краіна на тэрыторыі Палінезіі. Яна знаходзіцца ў сярэдзіне паўднёвай часткі Ціхага акіяна і мае статус самакіравальнай тэрыторыі ў свабоднай асацыяцыі з Новай Зеландыяй.	bel_Cyrl
+548	sports	Ilyo kwaba ukwaluka ukufuma kuli koota ukuya kuli citika ya ntamfu ya mulundu umo (mile), ukubutukisha takuba ukukankala sana lelo ukushipikisha ekufwaikwa sana.	bem_Latn
+824	travel	Uloleshe pa malendo yantu uwa kukwafwa alelandapo, cibe nipa webusaiti nangu pe windo lye shitolo.	bem_Latn
+1628	geography	Impendwa ya bantu mu Musumba wa Vatican yafika pali 800. Ekacalo akacepesha akaikwatila ubuntungwa pe sonde elyo kabili akacalo umwaba impendwa ya abantu iinono sana.	bem_Latn
+1596	science/technology	Ukweshaesha kwa sayansi ukwa fya mweo ukwa ba Hershey na ba Chase kwali cilangililo cimo ica letungililwa sana ukuti DNA yali ni mfyalo ya cintu.	bem_Latn
+739	geography	Ifishi fya Cook calo ca fishi icayampana mu buntungwa na New Zealand, icabela mu Polynesia, pakati ka South Pacific Ocean.	bem_Latn
+548	sports	চতুর্থাংশ থেকে অর্ধ মাইল দৌড় পরিবর্তনের সাথে সাথে গতি অনেক কম গুরুত্বপূর্ণ এবং ধৈর্য বেশি প্রয়োজনীয় হয়ে ওঠে।	ben_Beng
+824	travel	ওয়েবসাইট হোক শপ উইন্ডো, এজেন্ট কী ধরনের ট্রিপ প্রচার করছে সেদিকে নজর রাখুন।	ben_Beng
+1628	geography	ভ্যাটিকান সিটির জনসংখ্যা প্রায় 800। এটি বিশ্বের সবচেয়ে ক্ষুদ্রতম স্বাধীন দেশ এবং সবচেয়ে কম জবহুল দেশ।	ben_Beng
+1596	science/technology	ডিএনএ যে 1টি জেনেটিক উপাদান তার অন্যতম অগ্রণী প্রমাণ ছিল হার্শি এবং চেজ এর পরীক্ষা।	ben_Beng
+739	geography	কুক দ্বীপপুঞ্জ দক্ষিণ প্রশান্ত মহাসাগরের মাঝখানে পলিনেশিয়ায় অবস্থিত নিউজিল্যান্ডের সহযোগী একটি দ্বীপের দেশ।	ben_Beng
+548	sports	चौथाई से आधा मील के दौड़ के बदलाव के बाद, गति कम मायने रखेला आ धीरज राखल एकदम जरूरी हो जाला.	bho_Deva
+824	travel	ई जरुर देख लेईं कि एजेंट कउन-कउन ट्रिप के बतावत बा, चाहे उनकर वेबसाइट पर देखीं चाहे उनकर शॉप विंडो पर.	bho_Deva
+1628	geography	वैटिकन सिटी के आबादी लगभग 800 बा. ई दुनिया के सबसे छोट आजाद देस आ सबसे कम आबादी वाला देस ह.	bho_Deva
+1596	science/technology	डीएनए एगो आनुवंशिक सामग्री रहल ई सुझाव देवे वालन में एगो प्रमुख सुझाव हर्शे आ चेज़ प्रयोग रहल.	bho_Deva
+739	geography	कुक आइलैंड्स एगो द्वीप देशजवन दक्षिण प्रशांत महासागर के मध्य में, न्यूजीलैंड के संगे मुक्त सहयोगसे पोलिनेशिया में स्थितबा।	bho_Deva
+548	sports	لوان فروبهن متان بوکه سفرافة ميلل جدي ستڠه ميلل، کچفتن جدي تکوراڠ فنتيڠڽ وان کتهنن نڠ جدي کفرلوان اوتما.	bjn_Arab
+824	travel	جڠوکي فرجلنن اف هجا نڠ ديتوارکن اوله اݢين، بىإك ڠينتو دي سيتوس وىب اتوا نڠ دي اىستلسى توکو.	bjn_Arab
+1628	geography	ڤوڤولاسي كوتا فاتيكان ساكيتار ٨٠٠. ڠيني تو ناݢارا مارديكا تيهالوس دي دونيا وان ناݢارا لاوان ڤوڤولاسي تارينداه.	bjn_Arab
+1596	science/technology	ايكسڤيريمين هرصيي وان حاسي اياله سابوتيڠ ساران نڠ ڤامولاان باهووا د ن ا اياله ماتيري ݢينتيك.	bjn_Arab
+739	geography	کفولوان چووك إيله نݢراکفولوان دي اسوسياسيکن وان سلنديا برو، بأنداك دي فولينىسيا، دي تڠه سمودرا فسيفيك سلاتن.	bjn_Arab
+548	sports	Lawan parubahan matan bukah saparapat mill jadi satangah mil, kacapatan jadi takurang pantingnya wan katahanan nang jadi kaparluan utama.	bjn_Latn
+824	travel	Janguki perjalanan apa haja nang ditawarakan ulih agin, baik ngintu di situs web atawa nang di etalase tuku.	bjn_Latn
+1628	geography	Populasi kota Vatikan sakitar 800. Ngini tu nagara mardeka tehalus di dunia wan nagara lawan populasi tarendeh.	bjn_Latn
+1596	science/technology	Eksperimen Hershey wan Chase ialah salah sabuting saran nang pamulaan bahuwa DNA ialah matiri genetik.	bjn_Latn
+739	geography	Kapulauan Cook ialah negara kapulauan diasosiasikan wan Selandia Baru, baandak di Polinesia, di tangah Samudera Pasifik Selatan.	bjn_Latn
+548	sports	རྒྱུ་རྒྱུ་མ་ཡེལས་བཞི་ཆ་གཅིག་ནས་ཕྱེད་ལ་འགྱུར་བ་ཐེབས་པ་དེས་མགྱོགས་ཚད་ཀྱི་གལ་གནད་ཉུང་དུ་སོང་བ་དང་ངང་རྒྱུན་བསྟེན་རྒྱུ་དོན་དངོས་དུ་དགོས་ངེས་ཅན་ཞིག་ཆགས་།	bod_Tibt
+824	travel	དྲ་ཚིགས་ནང་དང་ཡང་ན་ཚོང་ཁང་གི་སྒེའུ་ཁུང་ནས་ངོ་ཚབ་པ་དེ་ཚོས་འགྲུལ་ཐེངས་ག་རེ་གོང་སྤེལ་བྱེད་ཀྱི་ཡོད་མེད་ལྟ་དང་།	bod_Tibt
+1628	geography	ཝེཀ་ཊི་ཀན་སི་ཊི་ཡི་མི་འབོར་ནི་800ཡས་མས་ཡིན་པ་དང་དེ་ནི་འཛམ་གླིང་ནང་གི་རང་བཙན་ལྡན་པའི་རྒྱལ་ཁྱབ་ཆུང་ཤོས་དང་མི་འབོར་ཉུང་ཤོས་ཀྱི་རྒྱལ་ཁབ་དེ་ཆགས་ཀྱི་ཡོད།	bod_Tibt
+1596	science/technology	ཧར་ཤེ་དང་ཅེས་གཉིས་ཀྱི་བརྟག་དཔྱད་དེ་ནི་ཌིཨེནཨེ་དེ་རིགས་རྫས་ཀྱི་རྒྱི་ཆ་ཡིན་པའི་བསམ་ཚུལ་བཏོན་མཁན་སྔ་གྲས་ཤིག་རེད།	bod_Tibt
+739	geography	ཀུཀ་མཚོ་གླིང་ནི་ནིའུ་ཟིལེནཌ་དང་འབྲེལ་བ་མེད་པའི་མཚོ་གླིང་གི་རྒྱལ་ཁབ་ཅིག་ཡིན་པ་དང་ལྷོ་ཞི་བདེའི་རྒྱ་མཚོའི་ནང་གི་པོལི་ནིཤིཡའི་ནང་ཆགས་ཡོད།	bod_Tibt
+548	sports	Prelaskom s trčanja na četvrtinu milje na trčanje na pola milje, brzina postaje mnogo manje važna, a izdržljivost postaje apsolutna potreba.	bos_Latn
+824	travel	Pogledajte koja putovanjima promoviše agent, na veb stranici ili u izlogu prodavnice.	bos_Latn
+1628	geography	Vatikan ima oko 800 stanovnika. To je najmanja nezavisna država na svijetu i država s najmanjim brojem stanovnika.	bos_Latn
+1596	science/technology	Hershey-Chaseov eksperiment je jedna od vodećih pretpostavki da je DNA genetski materijal.	bos_Latn
+739	geography	Cookovi otoci su otočna država u slobodnom pridruženju s Novim Zelandom, koja se nalazi u Polineziji, usred Južnog Tihog okeana.	bos_Latn
+548	sports	Rékko riliwengni siparape' mil lettu' sitengnga mil, déna napoko' lessinna larié.  Iyya riapparelluangngé iyanaritu atahangenna watakkalédé.	bug_Latn
+824	travel	Itaki aga na leleang paleleange, namu' lewa' onlain yare'ga ri telongeng gaddena.	bug_Latn
+1628	geography	populasina kota Vatikan iyanaritu kurang lebbi 800. Iyyé negara meredéka liwa' béccu' i na liwa' kurang jumlana populasinna.	bug_Latn
+1596	science/technology	Eksperimengna Hershey na Chase iyanaritu sala séddi pangaja poko' makkeddae DNA iyanaritu materi genetik.	bug_Latn
+739	geography	Allibukengna Cook iyyanaritu negara libukeng é iya engka é hubungang losna polé Selandia Baru, naiya monroé ri Polinesia, ri tenngana Samudera Pasifik ri attang	bug_Latn
+548	sports	С промяна на бягането от четвърт миля на половин миля, скоростта става много по-маловажна, докато издръжливостта става абсолютно необходима.	bul_Cyrl
+824	travel	Обърнете внимание какви пътувания промотира агентът, независимо дали на уебсайта или на витрината в магазина.	bul_Cyrl
+1628	geography	Населението на Ватикана е около 800 души. Това е държавата с най - малобройно население и най - малката независима държава в света.	bul_Cyrl
+1596	science/technology	Едно от водещите предположения, че ДНК е генетичен материал, беше експериментът, извършен от Хърши и Чейс.	bul_Cyrl
+739	geography	Островите Кук са островна държава със свободна асоциация с Нова Зеландия, намираща се в Полинезия, в средата на Южния Тихи океан.	bul_Cyrl
+548	sports	Amb el canvi de la cursa d'un quart a mitja milla, la velocitat esdevé molt més rellevant i la resistència esdevé una necessitat absoluta.	cat_Latn
+824	travel	Doneu un cop d'ull als viatges que promou l'agent, bé al lloc web, bé a la finestra de l'oficina.	cat_Latn
+1628	geography	La població de la Ciutat del Vaticà és d'unes 800 persones. És el país independent més petit al món i el país amb la població menor.	cat_Latn
+1596	science/technology	L'experiment de Hershey i Chase fou una de les primeres indicacions que l'ADN era un material genètic.	cat_Latn
+739	geography	Les illes Cook són un estat insular lliurement associat a Nova Zelanda, i es troben a la Polinèsia, al bell mig de l'oceà Pacífic sud.	cat_Latn
+548	sports	Kauban sa pagbag-o gikan sa kwarter ngadto sa katunga sa milya nga dagan, ang kakusog mahimong dili ana ka importante ug ang paglahutay mahimong hingpit nga kinahanglan.	ceb_Latn
+824	travel	Tan-awa kon unsang mga biyahe ang gina-promote sa ahente, sa website man o sa displeyhanan sa tindahan.	ceb_Latn
+1628	geography	Ang populasyon sa Siyudad sa Batikano kay anaa sa mga 800. Kini ang pinakagamay nga independenteng nasod sa kalibutan ug ang nasod nga pinakaubos ang populasyon.	ceb_Latn
+1596	science/technology	Ang eksperimento nga Hershey ug Chase kay usa ka mga nangunang sugyot nga ang DNA kay usa ka henetikong materyal.	ceb_Latn
+739	geography	Ang Cook Islands kay usa ka isla nga nasod nga libreng nakig-uban sa New Zealand, nga nahimutang sa Polynesia, sa tunga sa South Pacific Ocean.	ceb_Latn
+548	sports	Po změně ze čtvrt míle na půl se rychlost stává mnohem méně důležitou, zatímco výdrž se stává absolutní nutností.	ces_Latn
+824	travel	Podívejte se na zájezdy, které zástupce nabízí, ať už nabídku najdete na webu nebo ve výloze.	ces_Latn
+1628	geography	Populace Vatikánu zahrnuje okolo 800 obyvatel. Je to nejmenší nezávislá země na světě a země s nejnižší populací.	ces_Latn
+1596	science/technology	Hersheyho–Chaseové experiment byl jedním z hlavních důkazů, že je DNA genetický materiál.	ces_Latn
+739	geography	Cookovy ostrovy jsou ostrovní stát volně přidružený k Novému Zélandu. Nachází se v Polynésii uprostřed jižní části Tichého oceánu.	ces_Latn
+548	sports	Kwalumuna cha fuji mu kwalula, kuzomboka chaku keketesa ulemu henoho tachi mujipwa ja ulemo unji.	cjk_Latn
+824	travel	Tala ma wenhinguokapokolo kana wezela, cipue mu website handji mumue montra iya imue loja.	cjk_Latn
+1628	geography	Athu iya mbongue iya Vaticano ili kutwala iya 800. Cili cifuci independente mba cikehe ca mucifucinhicifucinhiathu akehe cindji.	cjk_Latn
+1596	science/technology	Wunhingiko wa Hershey and Chase kapwile nhi wunhingiko wupema há kutwala ADN capwile cakusemukanaco.	cjk_Latn
+739	geography	Mbaka ja Cook jili ifuchi inalifanhiukungulwilo wa Zelandia yaha, ili ha limbo lia Polinesia, mukachi ka kalunga luis wa kuuto “kusule”.	cjk_Latn
+548	sports	بە گۆڕانکاری لە چارەک بۆ نیو میل ڕاکردن، خێرایی گرنگی کەمتر دەبێت و خۆڕاگری دەبێتە پێویستیەکی ڕەها.	ckb_Arab
+824	travel	سەیرێک بکە بزانە بریکارەکە ڕیکلام بۆ چ گەشتێک دەکات، جا لە سەر وێبسایت یان لە پەنجەرەیەکی فرۆشگا.	ckb_Arab
+1628	geography	دانیشتوانی شاری ڤاتیکان نزیکەی 800 کەسن. بچووکترین وڵاتی سەربەخۆیە لە جیھاندا و وڵاتەکە کەمترین ژمارەی دانیشتوانی هەیە.	ckb_Arab
+1596	science/technology	تاقیکردنەوەی هێرشی و چەیس یەکێک بوو لە پێشنیارە پێشەنگەکان کە DNA مادەیەکی بۆماوەییە.	ckb_Arab
+739	geography	دوورگەکانی کوک بریتین لە وڵاتێکی دوورگە لە پەیوەندی سەربەخۆ لەگەڵ نیو زیلاند، کە دەکەوێتە پۆلینیسیا، لە ناوەراستی باشوری زەریای هێمن.	ckb_Arab
+548	sports	Çerik mil çapuvdan yarım mil çapuvğa keçkende, surat bayağı azca müim alğa kelir, çıdam ise mutlaq zaruret alına kelir.	crh_Latn
+824	travel	İnternet saifesinde ya da vitrinada agentniñ nasıl kezintilerniñ reklamasını yapqanını közden keçiriñiz.	crh_Latn
+1628	geography	Vatikannıñ ealisi 800 kişige yaqındır. Dünyanıñ eñ kiçik mustaqil ülkesi ve eñ alçaq ealige saip ülkedir.	crh_Latn
+1596	science/technology	Hershey ve Chaseniñ deñevi, DNE-niñ genetik material olğanına dair esas faraziyelerden biri edi.	crh_Latn
+739	geography	Kuk adaları, cenübiy Tınç okeannıñ ortasındaki Polineziyada bulunğan, Yañı Zelandiya ile serbest assotsiatsiyada olğan bir ada devletidir.	crh_Latn
+548	sports	Gyda'r newid o'r ras chwarter i hanner milltir, mae cyflymder yn dod yn llawer llai pwysig ac mae gwytnwch yn dod yn anghenraid llwyr.	cym_Latn
+824	travel	Cymerwch olwg ar ba deithiau mae'r asiant yn eu hyrwyddo, p'un ai ar wefan neu mewn ffenestr siop.	cym_Latn
+1628	geography	Tua 800 yw poblogaeth Dinas y Fatican. Dyma'r wlad annibynnol leiaf yn y byd a'r wlad sydd â'r boblogaeth isaf.	cym_Latn
+1596	science/technology	Roedd arbrawf Hershey a Chase yn un o'r awgrymiadau blaenaf fod DNA yn ddeunydd genetig.	cym_Latn
+739	geography	Mae Ynysoedd Cook yn wlad o ynysoedd mewn cymdeithas rydd â Seland Newydd, wedi eu lleoli ym Mholynesia, yng nghanol De'r Môr Tawel.	cym_Latn
+548	sports	Med ændringen af løbet fra en kvart til en halv mil, bliver løberens hastighed langt mindre vigtig, imens at udholdenhed bliver en absolut nødvendighed.	dan_Latn
+824	travel	Kig på de ture bureauet tilbyder enten på deres hjemmeside eller i deres butiksvindue.	dan_Latn
+1628	geography	Vatikanstatens befolkning er omkring 800. Det er det mindste uafhængige land i verden, og landet med den laveste befolkning.	dan_Latn
+1596	science/technology	Hershey and Chase eksperimentet var et af de førende forslag om, at DNA var et genetisk materiale.	dan_Latn
+739	geography	Cook-øerne er en østat i fri tilknytning til New Zealand, Øerne er beliggende i Polynesien, midt i det sydlige Stillehav.	dan_Latn
+548	sports	Durch den Wechsel vom Viertelmeilen- zum Halbmeilen-Rennen ist das Tempo weitaus weniger wichtig und Ausdauer eine absolute Notwendigkeit.	deu_Latn
+824	travel	Werfen Sie einen Blick auf die Reisen, die der Reisekaufmann auf der Webseite oder in einem Schaufenster bewirbt.	deu_Latn
+1628	geography	Die Vatikanstadt hat circa 800 Einwohner. Es ist der kleinste unabhängige Staat der Welt und das Land mit der kleinsten Bevölkerungszahl.	deu_Latn
+1596	science/technology	Das Hershey-Chase-Experiment war eines der maßgeblichen Indizien, dass DNA ein genetisches Material ist.	deu_Latn
+739	geography	Die Cookinseln sind ein Inselstaat, der frei mit Neuseeland assoziiert ist, und sie liegen in Polynesien in der Mitte des Südpazifiks.	deu_Latn
+548	sports	Gɛ̈ɛ̈r äwuur mën quarter kën mile bë ɣët käät half mile, äwuur äcï ɣïc bɛ̈n riɛl ku guɔ̈m dë ëyën kë cï bɛ̈n wïc äpεi.	dik_Latn
+824	travel	Däi käŋ käc ye raan gɛ̈tɛ̈ɛt luel, tënë website ku aluit dukan yic.	dik_Latn
+1628	geography	Kɔc tɔ̈u gen a 800. Ayen pan thin lääu nhom pinynhom ku ayen pan leŋ yic kɔc lik.	dik_Latn
+1596	science/technology	Äthëëm kɔc yë cɔl Hershey ku Chase ë yënë tou nhöm tueŋ käk yë luel lɔnadë DNA ë kë yë dhiëth kek kɔc riεmic ɣic.	dik_Latn
+739	geography	Cook thöny e pan thöny ka tɔ̈u kek New Zealand, ka tɔ̈u Polynesia, cɛl alɔŋ war South Pacific.	dik_Latn
+548	sports	Ni yèrèmanliyé kabô taran nanignan ma kassé taranko fila mayili borima, tériya kèni nafaya ma ani sôbèkôrô kanyara.	dyu_Latn
+824	travel	I gnaman la flè baralakèla ka tagamaw djéni lé mayarala yala inerinèti do kan wa boutiki dô filèwo la.	dyu_Latn
+1628	geography	Vatican dougou ya djaman beitah mogo kèmin ségui. Alle lobei yereimahorognat djamanan bieila fitini ye, wa alle djaman le fanan ka dogoh.	dyu_Latn
+1596	science/technology	Hershey ani Chase ya lônniya a toumbé kowba léyélônnitchèman mi ka yira ko ADNi bé jénétiki fin léyé.	dyu_Latn
+739	geography	Djin mi togo Cook, wé yé djamanan do lé ye mi ni New Zelandi bè ni ka djekourou do kè, a yé Polynesie cogodji mi togo Ocean pacifiqui, wé dougouman yoro ro.	dyu_Latn
+548	sports	རྒྱུགས་པའི་སྐབས་ལུ་ མའིལ་བཞི་དཔྱ་གཅིག་ལས་ ཕྱེད་ཀ་ལུ་ལྷོད་པའི་གནམ་དུས་ལུ་ མགྱོགས་ཚད་བ་འདི་ རྩ་འགེངས་ནི་འདི་ མེད་ཐབས་མེདཔ་ཅིག་ལུ་འགྱུར་དོ་ཡོདཔ་ཨིན།	dzo_Tibt
+824	travel	ལས་སྡེ་འདི་གིས་ ཁོང་རའི་ཡོངས་འབྲེལ་ནང་འབད་རུང་ཡང་ན་ ཚོང་ཁང་གི་སྒོ་ཅུ་ནང་འབད་རུང་ ག་ཅི་བཟུམ་ཅིག་གི་ སྐོར་འགྲུལ་ལུ་གཙོ་བོར་སྟོནམ་ཨིན་ན་ལྟ་དགོ།	dzo_Tibt
+1628	geography	ཝེ་ཀྲི་ཀཱན་ཁྲོམ་ཚོགས་ནང་ལུ་ མི་རློབས་༨༠༠དེ་ཅིག་ཡོདཔ་ཨིན། འ་ནི་འདི་ འཛམ་གླིང་ནང་ལུ་ རང་དབང་རང་བཙན་གྱི་རྒྱལ་ཁབ་ཆུང་ཤོས་ཅིག་དང་ མི་རློབས་ཉུང་ཤོས་ཅིག་ཡོད་མི་རྒྱལ་ཁབ་ཨིན།	dzo_Tibt
+1596	science/technology	ཧར་ཤེ་དང་ཅའསི་གིས་འབད་མི་ཚོད་བརྟག་འདི་ ཌི་ཨེན་ཨེ་ཟེར་མི་འདི་ རིགས་མཚན་གྱི་རྒྱུ་ཆ་ཨིན་ཟེར་བཀོད་མི་ཚུ་གི་གྲལ་ལས་ ཁག་ཆེ་ཤོས་ཅིག་ཨིན་མས།	dzo_Tibt
+739	geography	ཀུག་ཨའི་ལེནཊ་ཟེར་མི་ཚུ་ ལྷོ་ཕྱོགས་པེ་སི་ཕིག་རྒྱ་མཚོ་གི་བར་ན་ པོལི་ནི་ཤི་ཡ་ལུ་ཡོད་པའི་ མཚོ་གླིང་ཚུ་ཨིནམ་ད་ འདི་ཡང་ ནིའུ་ཟི་ལེནཊ་དང་གཅིག་ཁར་ མཉམ་འབྲེལ་ཡོད་པའི་ མཚོ་གླིང་རྒྱལ་ཁབ་ཅིག་ཨིན་མས།་	dzo_Tibt
+548	sports	Με την αλλαγή από τον αγώνα δρόμου ενός τέταρτου του μιλίου σε μισό μίλι, η ταχύτητα αποκτά λιγότερη σημασία και η αντοχή γίνεται απολύτως αναγκαία.	ell_Grek
+824	travel	Ρίξτε μια ματιά στα ταξίδια που προωθεί ο εκπρόσωπος, είτε στην ιστοσελίδα είτε σε βιτρίνα του καταστήματος.	ell_Grek
+1628	geography	Οι κάτοικοι της Πόλης του Βατικανού ανέρχονται περίπου στους 800. Αποτελεί το μικρότερο ανεξάρτητο κράτος στον κόσμο και αυτό με τον μικρότερο πληθυσμό.	ell_Grek
+1596	science/technology	Το πείραμα των Hersey και Chase αποτέλεσε μια από τις κύριες εισηγήσεις ότι το DNA είναι γενετικό υλικό.	ell_Grek
+739	geography	Τα Νησιά Κουκ είναι μια νησιωτική χώρα ελεύθερα συνδεδεμένη με τη Νέα Ζηλανδία και βρίσκονται στην Πολυνησία, στο κέντρο του νότιου Ειρηνικού ωκεανού.	ell_Grek
+548	sports	With the change from the quarter to the half mile run, speed becomes of much less importance and endurance becomes an absolute necessity.	eng_Latn
+824	travel	Take a look at what trips the agent is promoting, whether on a website or in a shop window.	eng_Latn
+1628	geography	Vatican City's population is around 800. It is the smallest independent country in the world and the country with the lowest population.	eng_Latn
+1596	science/technology	The Hershey and Chase experiment was one of the leading suggestions that DNA was a genetic material.	eng_Latn
+739	geography	The Cook Islands are an island country in free association with New Zealand, located in Polynesia, in the middle of the South Pacific Ocean.	eng_Latn
+548	sports	Kun la ŝanĝo de la kvaron- ĝis la duon-mejla kuro, rapido iĝas draste malpli grava kaj eltenemo iĝas absoluta necesaĵo.	epo_Latn
+824	travel	Rigardu kiajn vojaĝojn la agento reklamas, ĉu en retejo, ĉu en montrofenestro.	epo_Latn
+1628	geography	La loĝantaro de Vatikano estas ĉirkaŭ 800 personoj. Ĝi estas la plej malgranda sendependa ŝtato en la mondo kaj la ŝtato kun la plej malgranda loĝantaro.	epo_Latn
+1596	science/technology	La eksperimento de Hershey kaj Chase estis unu el la gvidaj supozoj pri tio, ke DNA estas genetika materialo.	epo_Latn
+739	geography	Kukinsuloj estas insula lando libere ligita al Nov-Zelando kaj situanta en Polinezio, meze de Suda Pacifiko.	epo_Latn
+548	sports	Tehes muutuse veerandi miili pikkusest jooksust poole miili peale, muutub kiirus vähem oluliseks ja vastupidavus muutub hädavajalikuks.	est_Latn
+824	travel	Vaadake veebisaidilt või vaateaknalt, milliseid reise agent reklaamib.	est_Latn
+1628	geography	Vatikani rahvaarv on umbes 800 inimest. See on väikseim iseseisev riik maailmas ja väikseima rahvaarvuga riik.	est_Latn
+1596	science/technology	Hershey ja Chase'i katse oli üks peamisi tõendeid, mis viitas sellele, et DNA on geneetiline materjal.	est_Latn
+739	geography	Cooki saared on saareriik, mis kuulub Uus-Meremaa vabasse assotsiatsiooni ja asub Vaikse ookeani lõunaosa keskosas Polüneesias.	est_Latn
+548	sports	Milia laurdeneko lasterketatik milia erdira aldatzean, abiadurak askoz garrantzi gutxiagoa dauka eta erresistentzia erabat beharrezkoa da.	eus_Latn
+824	travel	Eman begiratua agentziaren eskaintzei euren webgunean edo erakusleihoetan.	eus_Latn
+1628	geography	Vatikano Hiriak 800 biztanle ditu gutxi gorabehera. Munduko herrialde independente txikiena da, eta biztanle kopuru baxuena daukana.	eus_Latn
+1596	science/technology	Hershey eta Chase esperimentua izan zen DNA material genetikoa zela frogatzen zuen aztarna nagusienetako bat.	eus_Latn
+739	geography	Cook Uharteak uhartedi bat dira eta Zeelanda Berriarekin elkargo librea osatzen dute. Polinesian daude kokatuta, Hegoaldeko Ozeano Pazifikoaren erdian.	eus_Latn
+548	sports	Esime wonye nuwo le tͻtrͻm ta la, dzitsitsi meganye nu si le vevie o, ke ameɖokuidziɖuɖu kple kutrikukue le vevie.	ewe_Latn
+824	travel	Kpɔ mɔzɔzɔ ƒomevi si ŋu mɔzɔŋuti dɔwɔla la le nuƒom tsoe, eɖanye website dzi loo alo le fiase aɖe ƒe fesre dzi.	ewe_Latn
+1628	geography	Vatika dukͻa ƒe agbͻsͻsͻ nye 800. Eyae nye dukͻ xͻ ɖokui si suetͻ kekeake le xexea me.	ewe_Latn
+1596	science/technology	Hershey kple Chase ƒe nugͻmekuku nye ŋgͻgbetͻ siwo doe ɖa be טudzesi alo DNA nye lãmenu si tsoa amegbetͻ ƒe nutsotso wo dometͻ ɖeka.	ewe_Latn
+739	geography	Cook Fukpowo nye ƒukpo-dukɔ aɖe si le ɖekawɔwɔ me kple New Zealand, le Polynesia, le Anyiehe- Pasifik 'Tsiaƒu la ƒe titina.	ewe_Latn
+548	sports	Í mun til eina 400-m kapprenning, er ferð í eini 800-m kapprenning av minni týdningi, og úthaldni er nógv meira avgerandi.	fao_Latn
+824	travel	Hygg eftir hvørjar ferðir skrivstovan lýsir fyri, antin á einari heimasíðu ella í einum handilsvindeyga.	fao_Latn
+1628	geography	Har eru umleið 800 íbúgvar í Vatikanstatinum. Hann er minsta sjálvstøðuga landið í heiminum, og er tað landið, sum hevur minsta íbúgvaratalið.	fao_Latn
+1596	science/technology	Hershey og Chase kanningin var ein av leiðandi ávísingunum um, at DNA var arvaðfrøðiligt tilfar.	fao_Latn
+739	geography	Cookoyggjarnar eru eitt oyggjaland við leysum tilknýti til Nýsæland, sum liggja í Polynesia, mitt í Suðurkyrrahavinum.	fao_Latn
+548	sports	Ni rawa ni veisau totolo na nodra gutuwa, e bibi cake na nodra sasaga mera bula mai na nodra tolotolo.	fij_Latn
+824	travel	Mo raica rawa na mataqali gade vakacava e volitaka tiko, ena nona website se ena iloilo ni nona sitoa.	fij_Latn
+1628	geography	Na iwiliwili ni lewenivanua ena Siti o Vatican e 800. E matanitu lailai duadua e tu vakataki koya e vuravura qai lailai duadua na iwiliwili ni kena lewenivanua.	fij_Latn
+1596	science/technology	Na vakadidike nei Hershey kei Chase e kilai kina ni DNA e maroroya qai vakadewa na itukutuku ni kawa.	fij_Latn
+739	geography	Na Yatu kuka e tiko e Polinisia, ena loma donu ni Wasa Pasifika, qo e dua na yanuyanu e dau veimaliwai wale kei Niusiladi.	fij_Latn
+548	sports	Siirryttäessä neljännesmailista puolen mailin juoksuun nopeuden merkitys vähenee huomattavasti, ja kestävyydestä tulee ehdottoman välttämätöntä.	fin_Latn
+824	travel	Katso joko verkkosivulta tai liikkeen ikkunasta, millaisia matkoja edustaja tarjoaa.	fin_Latn
+1628	geography	Vatikaanivaltion asukasluku on noin 800. Se on maailman pienin itsenäinen valtio ja asukasluvultaan maailman pienin valtio.	fin_Latn
+1596	science/technology	Hersheyn ja Chasen tutkimus oli yksi tärkeimmistä viitteistä siitä, että DNA on geneettistä materiaalia.	fin_Latn
+739	geography	Cookinsaaret on Polynesiassa, Eteläisellä Tyynellämerellä sijaitseva saarivaltio. Se on Uuden-Seelannin liitännäisvaltio.	fin_Latn
+548	sports	Bɛsin ma dó ɛnɛ jɛ vlɔ dó we zunkinkan tɔn ɔ, wezun bleble kikan sɔ nɔ ɖo taji ǎ loɔ didɛ wɛ ɖò taji.	fon_Latn
+824	travel	Azɔ̀wàtɔ́ tomɛyiyi gbàsá tɔ́n ɖé ɖo tomɛyiyi ɖè jla wɛ hǔn‚ mi nɔ xɔ́tó.	fon_Latn
+1628	geography	Gbɛtɔ́ nu ɖi 800 mɔ̌ wɛ nɔ nɔ vatican toxò ɔ mɛ. E kpɔn gbè ɔ bǐ mɛ ɔ, é wɛ́ nyi tò kpɛví húgan ɖò tò e ko ɖò eɖésí lè mɛ bò lɛ ɖó togun tɔn è hwè hú bǐ é.	fon_Latn
+1596	science/technology	Hershey kpó Chase kpó wɛ blo dobanunu nukɔntɔn e xlɛ ɖɔ ADN wɛ nyi gù e ɖu tlɔlɔ sín mɛjitɔ lɛ si e.	fon_Latn
+739	geography	Tɔtɛntínto Cook lɛ ɔ‚ to ɖé wɛ yé nyǐ bó ɖò kpɔ xá Nouvelle Zelande to ɔ ɖò jlokokomɛ‚ é ɖò Polynésie ɖò xù Pacifique e ɖò tofɔligbé e tɛntin.	fon_Latn
+548	sports	Avec le passage du 400 mètres au 800 mètres, la vitesse devient beaucoup moins importante et l’endurance devient une nécessité absolue.	fra_Latn
+824	travel	Jetez un coup d’œil aux voyages dont l’agent fait la promotion, que ce soit sur un site internet ou en vitrine.	fra_Latn
+1628	geography	Le Vatican compte environ 800 habitants. C'est le plus petit pays indépendant au monde, et le moins peuplé.	fra_Latn
+1596	science/technology	L'expérience Hershey et Chase a été l'une des principales indications que l'ADN était un matériel génétique.	fra_Latn
+739	geography	L'archipel des îles Cook est un État en libre association avec la Nouvelle-Zélande, situé en Polynésie, au milieu de l'océan Pacifique sud.	fra_Latn
+548	sports	Cul cambiament da la corse di un cuart di mie a chê di mieze mie, la velocitât e je deventade mancul impuartante e la resistence e je deventade une necessitât assolude.	fur_Latn
+824	travel	Bute un voli a ce viaçs che al stâ promovint l’agjent, che al sedi suntun sît internet o su la vetrine de buteghe.	fur_Latn
+1628	geography	La popolazion de Citât dal Vatican e je di cirche 800 personis. E je la nazion indipendente plui piçule dal mont e la nazion cu la popolazion plui piçule.	fur_Latn
+1596	science/technology	L’esperiment di Hershey e Chase al è stât un dai principâi sugjeriments che il DNA al fos materiâl gjenetic.	fur_Latn
+739	geography	Lis isulis Cook a son un stât insulâr in libare associazion cu la Gnove Zelande, logât in Polinesie, intal mieç dal ocean Pacific meridionâl.	fur_Latn
+548	sports	Ɓe canji daga gotel ha darnai be je reta mile doggugo, yawugo warti do mari seeɗa nafu be jumriya warti do mari nafu manga.	fuv_Latn
+824	travel	A dinga larugo ko be sorrata, ha online ko ha window shago.	fuv_Latn
+1628	geography	Vatican wuro ummatore himbe yari kusan 800. Do on je mari sedda (independent) leddi ha dar duniyaru be je leddi be sedda dar ummatore.	fuv_Latn
+1596	science/technology	Jangirde be famrugo je Heshi be Ches on ardata ha hala wurti dow kuje goɗɗo mari ha ɓandu mako je fotata be je dada be baba mako kuje genetics on.	fuv_Latn
+739	geography	Cook Islands kanjum deddi je do ndiyam on je do narra wala kodume be New Zealand, je woni ha Polynesia, ha chaka Pacific Ocean je funa.	fuv_Latn
+548	sports	Tokko afraffaa irra gara walakaa maayili figuu jijjiiramuun barbaachisumaa saffisaa baay’ee xiqqaataa dhufa akkasumas jabeenyi guutumatti murteessaa ta’aa dhufa.	gaz_Latn
+824	travel	Bakka bu’aan imaloota akkamii akka beeksisaa jiru ilaali, marsariitii irrattis ta’e foddaa suuqii keessaan.	gaz_Latn
+1628	geography	Baayyinni uummata Magaalaa Vaatikaan naannoo 800. Kun addunyaarratti biyya of-dandeessu ishee hundarra xiqqoo fi biyya baayyina uummataa hundarra xiqqaa-aanaa qabduudha.	gaz_Latn
+1596	science/technology	Qorannoon Heersheeyi fi Cheesii yaadawwan jiraan keessa kan DNA’n meeshaa sanyii dabarsuu isaa jalqaba akka ta’etti geessu ture.	gaz_Latn
+739	geography	Ayislaandiin Cook ayislandoota bilisa kan walitti dhufeenya Niw Ziiland waliin, kan isheen itti argamtus Polineshiyati, garbaa kibbaa paasifikiiti argamti.	gaz_Latn
+548	sports	A’ dol o ruith cairteal de mhìle gu ruith leth-mhìle, chan eil luaths idir cho cudromach tuilleadh ach tha cian-fhulang dearg-riatanach.	gla_Latn
+824	travel	Thoir sùil air dè na tursan a tha an t-àidseant a’ brosnachadh, ge b’ ann air làrach-lìn no ann an uinneag bùtha.	gla_Latn
+1628	geography	Tha mu 800 duine a’ fuireach ann an Cathair na Bhatacain. ’S e an dùthaich neo-eisimeileach as lugha a th’ ann agus an dùthaich leis an àireamh-shluaigh as lugha.	gla_Latn
+1596	science/technology	B’ e deuchainn Hershey is Chase fear de na prìomh rudan a chuir an aire dhaoine gur e stuth ginteil a th’ ann an DNA.	gla_Latn
+739	geography	S e dùthaich eileanan a th’ ann an Eileanan Cook ’s a tha ann an co-chomann saor le Sealainn Nuadh, ann am Poilinèis am meadhan a’ Chuain Shèimh a Deas.	gla_Latn
+548	sports	Leis an athrú ón rith ceathrú míle go dtí an rith leath mhíle, maolaíonn tábhacht an luais agus méadaíonn an gá le seasmhacht.	gle_Latn
+824	travel	Féach ar na turais atá á gcur chun cinn ag an ngníomhaire, cibé ar láithreán gréasáin nó i bhfuinneog siopa.	gle_Latn
+1628	geography	Timpeall 800 duine atá i ndaonra Chathair na Vatacáine. Is í an tír neamhspleách is lú ar domhan agus an tír leis an daonra is ísle.	gle_Latn
+1596	science/technology	Bhí turgnamh Hershey agus Chase ar cheann de na príomh-mholtaí gur ábhar géiniteach a bhí in DNA.	gle_Latn
+739	geography	Is tír oileáin iad na hOileáin Cook a bhfuil stádas saorchomhlachais acu leis an Nua-Shéalainn, tá siad suite sa Pholainéis, i lár an Aigéin Chiúin Theas.	gle_Latn
+548	sports	Ao pasar da carreira dun cuarto de milla á media milla, a velocidade convértese en algo moito menos importante e a resistencia pasa a ser unha necesidade absoluta.	glg_Latn
+824	travel	Pódeselle botar unha ollada ás viaxes que o axente promove, tanto se é nun sitio web coma nun escaparate.	glg_Latn
+1628	geography	A poboación da Cidade do Vaticano ronda 800 persoas. É o país independente máis pequeno do mundo e o país co número de habitantes máis baixo.	glg_Latn
+1596	science/technology	O experimento realizado por Hershey e Chase foi unha das liderou a suxestión de que o ADN constitúe material xenético.	glg_Latn
+739	geography	As illas Cook son un país insular en asociación libre con Nova Zelandia, situadas na Polinesia, no medio do Océano Pacífico Sur.	glg_Latn
+548	sports	Oñemoambuévo peteĩ carrera orekóva un cuatro de milla-gui media milla-pe, pye'ekuee ndaha'evéima mba'eve ha resistencia katu iñambue peteĩ oñeikotevẽtévape.	grn_Latn
+824	travel	Ejesareko umi viaje agente oikuave'ẽva rehe, taha'e web renda térã peteĩ escaparate guive.	grn_Latn
+1628	geography	Vaticano Táva avaretakue ha’e 800 mil avakuéra rupi. Ha’e tetã isasõva michĩvéva yvy’ape’ári ha tetã oguerekóva sa’ive avakuéra.	grn_Latn
+1596	science/technology	Hershey y Chase experimento ha'eva'ekue mba'eguasuvéva haukáva  ADN ha'eha peteĩ material genético.	grn_Latn
+739	geography	Isla-kuéra Cook hína peteĩ tetã insular ojoajúva sãsóme Nueva Zelanda ndive, opytáva Polinesia-pe, Oceano Pacífico mbytépe.	grn_Latn
+548	sports	પા થી અડધા માઈલની દોડથી આવેલ બદલાવ સાથે, ઝડપ ખૂબ ઓછી મહત્વની બને છે અને સહન શક્તિ સંપૂર્ણ જરૂરીયાત બને છે.	guj_Gujr
+824	travel	વેબસાઇટ પર કે દુકાન પર એજન્ટો કઈ યાત્રાઓને પ્રમોટ કરે છે તે તપાસો.	guj_Gujr
+1628	geography	વેટિકન સિટીની વસ્તી 800 ની આસપાસ છે. તે વિશ્વનો સૌથી નાનો સ્વતંત્ર દેશ છે અને સૌથી ઓછી વસ્તી ધરાવતો દેશ.	guj_Gujr
+1596	science/technology	હર્શી એન્ડ ચેઝનો પ્રયોગ એ મુખ્ય સૂચનમાંનો એક હતો કે ડીએનએ એ આનુવંશિક સામગ્રી હતી.	guj_Gujr
+739	geography	કૂક આઇલૅન્ડ ન્યૂઝીલૅન્ડ સાથે મુક્ત રીતે જોડાયેલો ટાપુ દેશ છે, જે દક્ષિણી પ્રશાંત મહાસાગરમાં મધ્યમાં પૉલિનેશિયામાં આવેલો છે.	guj_Gujr
+548	sports	Avèk chanjman pou soti nan ka ale nan kous demi-mile lan, vitès la vin mwens enpòtan anpil epi andirans vin yon gwo nesesite.	hat_Latn
+824	travel	Fè yon gade nan ki vwayaj ajan an ap fè pwomosyon, si wi ou non sou yon sit entènèt oswa nan yon fenèt magazen yo.	hat_Latn
+1628	geography	Popilasyon site Vatikan an gen ozanviwon 800 abitan. Se pi piti peyi endepandan nan mond lan epi se peyi ki gen mwens moun.	hat_Latn
+1596	science/technology	Eksperyans Hershey ak Chase te youn nan prensipal sijesyon ADN yo te yon materyèl jenetik.	hat_Latn
+739	geography	Zile Kouk yo se yon peyi ki gen asosyasyon lib ak Nouvèl Zelann, li lokalize nan Polinezi, nan mitan oseyan pasifik sid.	hat_Latn
+548	sports	Da samun sauyi daga kwatan gudun rabin mil guda, batun gudu ya zama maras muhimmanci sosai yayin da jajircewa kuma ya zama wani abu na lallai.	hau_Latn
+824	travel	Lura da irin tafiye-tafiyen da wakili ke gabatarwa, ko a shafin yanar gizo ko a cikin taga shago.	hau_Latn
+1628	geography	Yawan al’ummar Birnin Vatican ya kai kimanin mutane 800. Ita ce kasa mafi kankanta cikin kasashe masu yancin kansu kuma mafi karancin yawan jama’a.	hau_Latn
+1596	science/technology	Gwajin Hershey da Chase na ɗaya daga cikin ra’ayoyin da ke kan gaba da ke nuni da cewa DNA wani abu ne na rayuwa.	hau_Latn
+739	geography	Tsibirin Cook tsibiri ce wanda ba ta da alaka tare da New Zealand, wanda ke cikin Polynesia, a tsakiyar Tekun Pacific ta Kudu.	hau_Latn
+548	sports	עם המעבר מריצה של רבע מייל לחצי מייל, המהירות הופכת פחות חשובה וכושר הסיבולת הופך להיות הכרח מוחלט.	heb_Hebr
+824	travel	התבוננו באילו טיולים הסוכן מקדם, בין אם באתר או בחלון החנות.	heb_Hebr
+1628	geography	אוכלוסיית קריית הוותיקן היא 800 איש בערך. זו המדינה העצמאית הקטנה ביותר בעולם והמדינה עם האוכלוסייה המועטה ביותר.	heb_Hebr
+1596	science/technology	ניסוי הרשי וצ'ייס היה אחת הטענות המובילות לכך ש-DNA הוא חומר גנטי.	heb_Hebr
+739	geography	איי קוק הם מדינת אי שקשורה קשר רופף לניו זילנד, ונמצאים בפולינזיה, במרכז האוקיינוס השקט הדרומי.	heb_Hebr
+548	sports	तिमाही से आधे-मील तक के बदलाव के साथ, गति बहुत कम महत्व की हो जाती है और स्थिरता एक अत्यंत आवश्यकता बन जाती है.	hin_Deva
+824	travel	चाहे आप कोई वेबसाइट देख रहे हों या किसी शॉप की विंडो पर हों, इस बात पर एक नज़र डालें कि एजेंट किन यात्राओं का प्रचार कर रहा है.	hin_Deva
+1628	geography	वेटिकन सिटी की जनसंख्या लगभग 800 है. यह विश्व का सबसे कम जनसंख्या वाला सबसे छोटा स्वतंत्र राष्ट्र है.	hin_Deva
+1596	science/technology	हर्शे और चेस के परीक्षण का एक प्रमुख सुझाव था कि DNA एक जेनेटिक मटेरियल था.	hin_Deva
+739	geography	कुक आइलैंड्स दक्षिण प्रशांत महासागर के बीच में पोलिनेशिया में स्थित एक द्वीप देश है,जिसका नूजीलैंड के साथ खुला सहयोग है ।	hin_Deva
+548	sports	चौथाई ले आधा मील के दौड़ म परिवर्तन के साथ, गति बहुत कम महत्व के रहे जात हवय अउ धीरज एकठन परम ज़रूरत बन जात हवय।	hne_Deva
+824	travel	एक बार ध्यान देवव कि एजेंट कोन से यात्रा मन के प्रचार करत हवय, चाहे वो ह वेबसाइट म हो या दुकान के खिड़की म।	hne_Deva
+1628	geography	वेटिकन सिटी के आबादी लगभग 800 हे।ए दुनिया के सबले छोटे स्वतंत्र देश अऊ सबले कम आबादी वाला देश हवे।	hne_Deva
+1596	science/technology	हर्शे अउ चेज़ प्रयोग प्रमुख सुझावमन म ले एकठन रहिस कि डीएनए एकथन आनुवंशिक सामग्री रहिस।	hne_Deva
+739	geography	कुक आइलैंड्स दक्षिण म प्रशांत महासागर के बीच, पोलिनेशिया म स्थित न्यूजीलैंड के संग मुक्त सहयोग म एक द्वीप देश हे।	hne_Deva
+548	sports	S promjenom dužine utrke s četvrt milje na pola milje, brzina postaje mnogo manje važna, a izdržljivost postaje apsolutna nužnost.	hrv_Latn
+824	travel	Pogledajte kakve izlete agent promovira, bilo na web-lokaciji ili u izlogu.	hrv_Latn
+1628	geography	Broj stanovnika Vatikana iznosi oko 800. Riječ je o najmanjoj neovisnoj zemlji na svijetu i zemlji s najmanjim brojem stanovnika.	hrv_Latn
+1596	science/technology	Eksperiment koji su izveli Hershey i Chase bio je jedan od vodećih prijedloga da je DNK genetski materijal.	hrv_Latn
+739	geography	Cookovi otoci otočna su država, samoupravno područje Novoga Zelanda koje se nalazi u Polineziji, usred južnog Pacifičkog oceana.	hrv_Latn
+548	sports	Futásnál, ha negyedmérföldes távról félmérföldesre vált valaki, akkor a sebességnek már kisebb jelentősége lesz, azonban az állóképesség feltétlenül szükségessé válik.	hun_Latn
+824	travel	Nézze meg, milyen utazásokat reklámoz az ügynök akár egy webhelyen, akár egy bolti kirakatban!	hun_Latn
+1628	geography	Vatikánváros népessége körülbelül 800 fő. Ez a legkisebb és legalacsonyabb népességű független ország a világon.	hun_Latn
+1596	science/technology	A Hershey és Chase kísérlet egyike volt annak az elméletnek legfőbb bizonyítékainak, miszerint a DNS egy genetikai anyag.	hun_Latn
+739	geography	A Cook-szigetek Új-Zéland társult szigetországa,  Polinéziában, a Csendes-óceán déli részének közepén.	hun_Latn
+548	sports	Եթե մեկ քառորդը փոփոխվում է կես մղոնի վազքով, արագությունը կորցնում է իր կարևորությունը, և տոկունությունը դառնում է բացարձակ անհրաժեշտություն:	hye_Armn
+824	travel	Նայեք, թե ինչ ճանապարհորդություններ է գովազդում գործակալը թե՛ կայքում և թե՛ ցուցափեղկում:	hye_Armn
+1628	geography	Վատիկան քաղաքի բնակչությունը շուրջ 800 է։ Այն աշխարհի ամենափոքր անկախ և ամենաքիչ բնակչությունն ունեցող պետությունն է։	hye_Armn
+1596	science/technology	Հերշիի և Չեյզի փորձը գլխավոր առաջարկություններից մեկն էր, որ ԴՆԹ-ն ծագումնաբանական նյութ է:	hye_Armn
+739	geography	Կուկի կղզիները կղզի-երկիր են, որն ազատ հարաբերություններ ունի Պոլինեզիայում տեղակայված Նոր Զելանդիայի հետ` Խաղաղ օվկիանոսի հարավային միջնամասում:	hye_Armn
+548	sports	Ya na ngbanwe site n'ịgba ọsọ nkeji iri na ise ruo ọkara maịlị, mkpa èkwòmọsọ adịzie nnọọ obere ma ntachi obi na-abụ ihe dị oke mkpa.	ibo_Latn
+824	travel	Lee anya na ihe njem oje ozi na ebuli elu, ma o bu na webusaiti ma o bu na windo ulo ahia.	ibo_Latn
+1628	geography	Onu ogugu ndi mmadu obodo Vatican di nari 800. O bu obodo kacha nta n’uwa n’uwa n’uwa na obodo n’ogbe ndi kacha pere mpe.	ibo_Latn
+1596	science/technology	Nwale Hershey na Chase so na otu aro no na isi siri na DNA wubu otu mkpụrụ ndụ ihe nketa.	ibo_Latn
+739	geography	Isuo Kuk bụ obodo isuo nọ n'etiti ndịda oke osimiri Pasifik, nke dị na Polinesia ya na obodo Niu Zilandị gbara ogige nwere onwe.	ibo_Latn
+548	sports	Iti panagbaliw ti panagtaray manipud iti kakapat ti milia a mapan iti kagudua ti milia, saan unayen nga importante ti kinapardas ket ti kinaibtur ti agbalinen a nangnangruna a kasapulan.	ilo_Latn
+824	travel	Kitaem no ania dagiti biahe nga italtal-o ti ahente, maipapan iti website wenno iti tawa ti paglakuan.	ilo_Latn
+1628	geography	Ti populasion ti Vatican City ket agarup 800. Daytoy ti kabassitan a nawaya a pagilian iti lubong ken ti pagilian nga addaanti kabassitan a populasion.	ilo_Latn
+1596	science/technology	Ti eksperimento ti Hershey ken Chase iti maysa kadagiti nalatak nga agibagbaga a ti DNA ket genetiko a material.	ilo_Latn
+739	geography	Ti Cook Islands ket maysa nga isla a nasion nga adda nawaya a pannakainaigna iti New Zealand, a makita idiay Polynesia, ti tengnga iti Makin-abagatan a Baybay Pasipiko.	ilo_Latn
+548	sports	Dengan perubahan dari lari seperempat mil menjadi lari setengah mil, kecepatan menjadi kurang penting dan daya tahan menjadi kebutuhan mutlak.	ind_Latn
+824	travel	Pelajari perjalanan apa saja yang dipromosikan agen tersebut, entah itu di situs web maupun di etalase toko.	ind_Latn
+1628	geography	Populasi Kota Vatikan sekitar 800. Ini adalah negara merdeka terkecil di dunia dan negara dengan populasi terendah.	ind_Latn
+1596	science/technology	Percobaan Hershey dan Chase merupakan salah satu usulan utama yang menyatakan bahwa DNA adalah materi genetik.	ind_Latn
+739	geography	Kepulauan Cook adalah negara kepulauan yang berasosiasi bebas dengan Selandia Baru, lokasinya di Polinesia, di tengah-tengah Samudra Pasifik Selatan.	ind_Latn
+548	sports	Þegar hlaupið var lengt úr fjórðungi úr mílu í hálfa mílu varð hraðinn ekki nærri eins mikilivægari heldur var úthald algert lykilatriði.	isl_Latn
+824	travel	Skoðaðu hvaða ferðir fulltrúinn er að auglýsa, hvort sem þær eru á vefsíðu eða í búðarglugga.	isl_Latn
+1628	geography	Íbúar Vatikanborgar eru um 800. Það er minnsta sjálfstæða landið í heiminum og með minnstan fólksfjölda.	isl_Latn
+1596	science/technology	Tilraun Hershey og Chase var ein af leiðandi tillögum þess efnis að DNA væri erfðaefni.	isl_Latn
+739	geography	Cooks-eyjar er eyjaríki í frjálsu sambandi við Nýja-Sjáland, staðsett í Pólýnesíu, í miðju Suður-Kyrrahafi.	isl_Latn
+548	sports	Passando dal quarto di miglio al mezzo miglio, la velocità diventa molto meno importante, mentre la resistenza diventa una vera e propria necessità.	ita_Latn
+824	travel	Date un'occhiata ai viaggi che promuove l'agente, sia sul sito web che in vetrina.	ita_Latn
+1628	geography	La popolazione della Città del Vaticano è costituita da circa 800 abitanti. Si tratta dello Stato indipendente più piccolo al mondo e quello con la minor popolazione.	ita_Latn
+1596	science/technology	Uno dei primi esperimenti a suggerire che il DNA fosse un materiale genetico è stato quello condotto da Hershey e Chase.	ita_Latn
+739	geography	Le Isole Cook si trovano in Polinesia, nel centro dell'Oceano Pacifico meridionale; costituiscono uno Stato insulare in libera associazione con la Nuova Zelanda.	ita_Latn
+548	sports	Kanthi owah-owahan saka puteran seprapat mil, kacepetan dadi ora pati penting lan kakukuhan dadi kabutuhan mutlak.	jav_Latn
+824	travel	Coba delengen wisata apa sing dipromosikke dening agen iki, ana ning situs web utawa ana cendhela kaca toko.	jav_Latn
+1628	geography	Populasi Kutha Vatikan watara 800. Iku negara mardika paling cilik ing donya lan negara kanthi pendhudhuk paling sethithik.	jav_Latn
+1596	science/technology	Eksperimen Harshey lan Chase iku salah sawijining unsur-unsur utama menawa DNA iku sawijining bahan genetik.	jav_Latn
+739	geography	Kapuloan Cook iku negara pulo ing asosiasi bebas karo Selandia Baru, panggonane ing Polinesia, ing tengah-tengah Samudra Pasifik Kidul.	jav_Latn
+548	sports	クォーターマラソンからハーフマラソンに転向する場合、スピードの重要性ははるかに低くなり、持久力が絶対的に必要になります。	jpn_Jpan
+824	travel	ウェブサイトや店頭で、代理店がどのような旅行を宣伝しているかを見てみましょう。	jpn_Jpan
+1628	geography	バチカン市国の人口は約800人です。世界最小の独立国であり、最も人口が少ない国でもあります。	jpn_Jpan
+1596	science/technology	ハーシーとチェイスの実験は、DNAが遺伝物質であることを示唆する有力な実験の1つでした。	jpn_Jpan
+739	geography	クック諸島は、南太平洋の中央に位置するポリネシアに属し、ニュージーランドと自由連合を結んだ島国です。	jpn_Jpan
+548	sports	S ubeddel si tazzla n ṛbeɛ ɣer uzgen n lmil, tazzla yuɣal inqes wazal-is ma d azbu yuɣal d lmeḥwiǧat tamezwarut.	kab_Latn
+824	travel	Wali acu n yinigen i tettdellil tkebbanit, ama di tansa-nes n anternet ama di ṭaq n tḥanutt-is.	kab_Latn
+1628	geography	Uṭun n imezdaɣ n Batikan Siti 800. D tamurt tamunant tamecṭuḥt yakk di ddunit yarna d tamurt akk isɛan ciṭ n imezdaɣ.	kab_Latn
+1596	science/technology	Tirmit n Hercey akked Čays d yiwet id-iseknen belli ADN d tanga n lewrata.	kab_Latn
+739	geography	Tigzirin n Kuk d tamurt n tegzirin idukklen s wudem ilelli akked Zilanda Tamaynut, tezga-d di Bulinizya, di tlemmast n Ugaraw Irsen n Unẓul.	kab_Latn
+548	sports	Kagat ai lam hpe deng htam mali na htam mi sha re ai kaw na deng chyen mi rai mat ai a majaw, ndai kagat ai lam hta ba lu hkam ai lam gaw chyang shadang hta grau ahkyak mat wa ai.	kac_Latn
+824	travel	Website kaw rai rai madun da ai seng kaw rai rai hkrun lam lajang ai ni hpe ni ndau shabra da ai hpe yu yu u.	kac_Latn
+1628	geography	Vatican Mare kaba gaw masha jahpan 800 sha nga ai. Dai gaw mungkan na kaji htum shanglawt mungdan re nna masha jahpan nlaw htum mungdan rai nga ai.	kac_Latn
+1596	science/technology	Hershey hte Chase a hkaja ai lam gaw DNA gaw genetic rai re ai ngu tak ai ni kaw na langai re wa ai.	kac_Latn
+739	geography	Cook Islands ngu ai zunlawng mungdan gaw Dingda Pacific nammuk dara a ka'ang na, Polynesia ngu ai shara kaw nga ai, New Zealand mungdan hte kanawn mazum lam, matut mahkai lam nga ai mungdan langai rai nga ai.	kac_Latn
+548	sports	Nũndũ wa ũalyũko kuma ĩsemba ya kwota kũthi ya nusu ya maĩli, vata wa mĩtũkĩ yu ti munene mũno naw'o ũũmĩĩsyo ũtw'ĩkĩte wa vata vyũ.	kam_Latn
+824	travel	Sisya ndambuka ila mbuloka ukukunia maleve, yithiwe ni mitandaoni kana ndilisyani ya nduka.	kam_Latn
+1628	geography	Utalo wa eakli ma musyi munene wa Vatican ni ta 800. Niyo nthi niini vyu yiulu wa nthi yisumbikite na ila yi utalo muniini wa ekali.	kam_Latn
+1596	science/technology	Utatithyo uu wa Hershey na Chase niw'o unatongoetye kana DNA yai kindu kya ngyenetiks.	kam_Latn
+739	geography	Cook Island ni nthi yi kati kati wa kiw'u ina ngwatanio na New Zealand, yi nthini wa Polynesia, kati kati wa itheo ya Pacific ocean.	kam_Latn
+548	sports	ಕಾಲು ಮೈಲಿಯಿಂದ ಅರ್ಧ ಮೈಲಿಗೆ ಓಟದ ಬದಲಾವಣೆಯಿಂದ, ವೇಗದ ಪ್ರಾಮುಖ್ಯತೆ ಕಡಿಮೆಯಾಗಿ ಸಹಿಷ್ಣುತೆ ಸಂಪೂರ್ಣ ಅನಿವಾರ್ಯ ಆಗುತ್ತದೆ.	kan_Knda
+824	travel	ತನ್ನ ವೆಬ್‍‌ಸೈಟ್‌ನಲ್ಲಿ  ಅಥವಾ  ಅಂಗಡಿಯಲ್ಲಿ ಆ ಎಜಂಟ್ ಎಂತಹ ಪ್ರವಾಸಗಳನ್ನು   ಪ್ರಚಾರ ಮಾಡುತ್ತಿದ್ದಾನೆಂದು ಒಮ್ಮೆ ಪರಿಶೀಲಿಸಿ.	kan_Knda
+1628	geography	ವ್ಯಾಟಿಕನ್ ಸಿಟಿಯ ಜನಸಂಖ್ಯೆ ಸುಮಾರು 800ರಷ್ಟಿದೆ. ಅದು ಪ್ರಪಂಚದ ಅತ್ಯಂತ ಚಿಕ್ಕ ಸ್ವತಂತ್ರ ರಾಷ್ಟ್ರವಾಗಿದ್ದು ಪ್ರಪಂಚದ  ಅತ್ಯಂತ ಕಡಿಮೆ ಜನಸಂಖ್ಯೆಯ ರಾಷ್ಟ್ರವೂ ಅದೇ ಆಗಿದೆ.	kan_Knda
+1596	science/technology	ಹರ್ಷೇ ಮತ್ತು ಚೇಸ್‌ರ ಪ್ರಯೋಗ, DNA ಒಂದು ಅನುವಂಶಿಕ ವಸ್ತು ಎಂಬುದನ್ನು ಸೂಚಿಸುವ ಒಂದು ಮಹತ್ವದ ಪ್ರಯೋಗವಾಗಿದೆ.	kan_Knda
+739	geography	ದಕ್ಷಿಣ ಪೆಸಿಫಿಕ್ ಸಮುದ್ರದ ಮಧ್ಯದಲ್ಲಿ ಪಾಲಿನೇಶಿಯಾದಲ್ಲಿರುವ, ನ್ಯೂಜಿಲೆಂಡ್ ಜೊತೆಗೆ ಮುಕ್ತ ಸಹಭಾಗಿತ್ವದಲ್ಲಿರುವ ದ್ವೀಪ ದೇಶವು ಕೂಕ್ ಐಲ್ಯಾಂಡ್ಸ್ ಆಗಿದೆ.	kan_Knda
+548	sports	یُتھۍ دۄر چھ بدلان دوون پیٹھہٕ نصف میلس تام، رفتار چھِ واریاہ کم اہمیت تھاوان تہٕ بییہٕ برداشت آسُن چُھ بنان ضروری۔	kas_Arab
+824	travel	اکھ نظر ترٲیو زٕ ایجنٹ کمن دورن چُھ فروغ دِوان، یا سو ویب سائٹہٕ پیٹھ ٲسِن یا دکانچہٕ دارِ پیٹھ۔	kas_Arab
+1628	geography	ویٹیکن سٹی ہٕنٛز آبٲدی چھےٚ لگ بگ 800 ۔ یہ چھُ دنیاہُک ساروٕے کھۄتہٕ لۄکُٹ آزاد ملک تہٕ ساروٕے کھۄتہٕ کم آبٲدی وول ملک۔	kas_Arab
+1596	science/technology	ہرشی تہٕ چیزن تجربہ اوس اکھ اہم تجاویزو منز کہِ ڈۍ این اے DNA اوس اکھ جنیٹیک مواد۔	kas_Arab
+739	geography	کک جزیر چِھ نیوزٕ لینڈس سۭتۍ آزادانہٕ تعاون تھاون وول اکھ جزیرٕ ملک، یُس جنوبی پیسفیک سمندرکس وسطس منٛز پولینیشیا ہس منٛز واقعہٕ چُھ۔	kas_Arab
+548	sports	चूरमि हिस पेठ हाफ मील दोरि हिंज़ तबदीली साथि, रफ्तार छा वारयह कम ज़रूरि बनान ति बर्दाश्त छु असली हकीकत बनान ।	kas_Deva
+824	travel	अख नज़र त्रायव की एजेंट काम दोरान हुंड फारोग चू दीवान, चाहे वेबसाइट्स पेठ चू या दुकांची दारी मन्ज़।	kas_Deva
+1628	geography	वेटिकन सिटी हीच आबादी छु 800 ताम। यि छु दुनियहूक सारवी खोत लकुट आज़ाद मुल्क ति सारवी खोत कम आबाद मुल्क।	kas_Deva
+1596	science/technology	हेरशे (Hershey) ति चेस (Chase) सुंद तजरूब छु अख अहम तजवीज़ कि DNA ओस अख जिनयाती मवाद ।	kas_Deva
+739	geography	कूक आयलेन्डस (Cook Islands) छा अख जजीर्ण ह्युंद मुल्क निव ज़िलेनडस (New Zealand) साथि आज़ाद तआववुन साथि, युस जनूबी बेहरि अलकाहिलस (South Pacific Ocean) मंज़ बाग पोलिनेशिया (Polynesia) हस मंज़ वाकह छा ।	kas_Deva
+548	sports	ნახევარ მილზე მეოთხედიდან გადასვლისას სიჩქარე ნაკლებად მნიშვნელოვანია, გამძლეობა კი სასიცოცხლო აუცილებლობა ხდება.	kat_Geor
+824	travel	დაუკვირდით, აგენტი ვებ-გვერდზე, ან მაღაზიის ვიტრინაში რა მოგზაურობას უწევს რეკლამას.	kat_Geor
+1628	geography	ვატიკანში დაახლოებით 800 ადამიანი ცხოვრობს. იგი მსოფლიოს ყველაზე პატარა დამოუკიდებელი ქვეყანაა, მოსახლეობის ყველაზე მცირე რაოდენობით.	kat_Geor
+1596	science/technology	დნმ რომ გენეტიკური მასალაა, ჰერშის და ჩეიზის ექსპერიმენტის ერთ-ერთი ძირითადი მოსაზრება იყო.	kat_Geor
+739	geography	კუკის კუნძულები კუნძულოვანი სახელმწიფოა, რომელიც თავისუფალ ასოციაციაშია ახალ ზელანდიასთან და პოლინეზიაში, წყნარი ოკეანის სამხრეთ ნაწილშია განთავსებული.	kat_Geor
+548	sports	Ширектен жарты мильге жүгіргенде жылдамдықтың маңызы азаяды және төзімділік абсолютті қажеттілікке айналады.	kaz_Cyrl
+824	travel	Тыңшы қандай веб-сайттарда немесе дүкен терезелерінде жүргенін қараңыз.	kaz_Cyrl
+1628	geography	Ватикан қаласы халқының саны — шамамен 800. Бұл — дүние жүзіндегі ең шағын тәуелсіз ел және халық саны ең аз ел.	kaz_Cyrl
+1596	science/technology	Херши және Чейздің эксперименті ДНҚ генетикалық материал болып табылады деген жетекші ұсыныстардың біреуі болды.	kaz_Cyrl
+739	geography	Кук аралдары — Жаңа Зеландиямен еркін ассоциация құрған, Полинезияда, Оңтүстік Тынық мұхитының ортасында орналасқан аралдық ел.	kaz_Cyrl
+548	sports	Eyaa ese sɩ kiloomɛta hɔlaɣ kʋyɩmaɣ naanza yɔɔ, seya pɩsɩ mbʋ pɩwɛ waɣsaɣ pɩtɩɩfɛyɩ nɛ ɖoŋ kpaɣʋ pɩsɩ wazaɣ pʋƴʋ kpem.	kbp_Latn
+824	travel	Ɩyaɣ ɛsɩyɛ nʋmaŋ weyi ɛgbɛyɛ taa tʋmlaɖʋ seɣtiɣ ɛyaa se powolo yɔ ɩ-yɔɔ nɛ ɩna, paa pɩtɩɩkɛ ɛntɛrɩnɛɛtɩ lone naɖɩyɛ yɔɔ yaa wondu ɖɩzɩyɛ naɖɩyɛ taa kɔyɔ.	kbp_Latn
+1628	geography	Vatikan ɛjaɖɛ taa mba kpendiɩ zɩɩ 800 yɔ. Ɖɩ-kɛ kajalaɣ ɛjaɖɛ cikpeɖe kpaagbaa nɖɛ nɖɩ ɖɩ-wɛ ɖɩ-dɩ yɔɔ kɩdeŋ kpekpe yɔɔ yɔ nɛ ɖɩ-kɛ ɖɔɖɔɔ ajɛya wena a-samasɩ tɔ-ɖɔɔ yɔ a-taa kpagbaa nɖɛ.	kbp_Latn
+1596	science/technology	Hershey nɛ Chase maɣsɩʋ wɩlaɣ se ADN maɣyaɣ kɛ maɣyaɣ ŋga kawɩlɩɣ akele ne akele lɛ paka calɩm paɣyaɣ ɖamaa nabʋyʋ?.	kbp_Latn
+739	geography	Kuuki lɩm hɛkʋ taa tɛtʋ kɛ ɛjaɖɛ nɖɩ ɖɩtam nɔɔ faaa nɛ Nuvɛɛlɩ-zelandɩ yɔ, nɛ tɩwɛ Polineezii, Pasiifiki nɛ hadɛ kiŋ teŋgu sɔsɔʋ hɛkʋ taa.	kbp_Latn
+548	sports	Ku mudansa di kuartu pa meiu kilómetru, velosidadi ta fika mutu ménus inpurtanti y rizisténsia ta bira un nisisidadi absulutu.	kea_Latn
+824	travel	Konsulta viajens ki ajenti sa ta promove, na website ô nun montra di un loja.	kea_Latn
+1628	geography	Populason di Sidadi di Vatikanu é di serka di 800 abitanti. É país indipendenti más pikinoti di mundu y país ku populason más poku.	kea_Latn
+1596	science/technology	Spiriénsia di Hershey y Chase foi un di kes prinsipal sujeston ma ADN éra un material jenétiku.	kea_Latn
+739	geography	Ilhas Cook é un país insular ku livri asosiason ku Nova Zelándia, lokalizadu na Polinézia, na meiu di Osianu Pasífiku di sul.	kea_Latn
+548	sports	Дөрөвний нэгээс хагас милийн гүйлт болгож өөрчлөхөд, хурд төдийлөн чухал байхаа больж, тэсвэр тэвчээр нь туйлын шаардлага болдог.	khk_Cyrl
+824	travel	Агент ямар аяллыг сурталчилж байгааг вэб сайт дээрээс нь эсвэл дэлгүүрийнх нь цонхоор хараад аваарай.	khk_Cyrl
+1628	geography	Ватикан хотын хүн ам ойролцоогоор 800 хүн байдаг. Энэ бол дэлхий дээрх хамгийн жижиг тусгаар тогтносон улс, хамгийн бага хүн амтай улс юм.	khk_Cyrl
+1596	science/technology	Херши болон Чэйз нарын туршилт нь ДНХ-г генетикийн материал болохыг санал болгосон голлох туршилтын нэг байв.	khk_Cyrl
+739	geography	Күүкийн арлууд нь Өмнөд Номхон далайн дунд байх Полинезид байрладаг бөгөөд Шинэ Зеландтай чөлөөт холбоотой арал улс юм.	khk_Cyrl
+548	sports	ជាមួយនឹង​ការ​ផ្លាស់ប្ដូរ​ពី​មួយ​ភាគ​បួន​ទៅ​ការ​រត់​ពាក់​កណ្តាល​ម៉ាយ នោះ​ល្បឿន​ក៏​ក្លាយ​ជា​មិន​សូវ​សំខាន់ ហើយ​ការ​ខំប្រឹង​ក៏​ក្លាយ​ជា​ភាព​ចាំបាច់​បំផុត។	khm_Khmr
+824	travel	សូមក្រឡេកមើលដំណើរកំសាន្ត​ដែលភ្នាក់ងារកំពុងផ្សព្វផ្សាយ​ នៅលើគេហទំព័រក្តី​ឬនៅតាមបង្អួចទ្វាក្តី។	khm_Khmr
+1628	geography	ចំនួនប្រជាជនសរុបនៅទីក្រុងវ៉ាទីកង់មានប្រហែល 800 នាក់។ វាគឺជាប្រទេសឯករាជ្យដែលតូចជាងគេបំផុតនៅលើពិភពលោក ហើយក៏ជាប្រទេសដែលមានប្រជាជនតិចជាងគេបំផុតផងដែរ។	khm_Khmr
+1596	science/technology	ការពិសោធន៍របស់ហឺស្ហេយ៍ (Hershey) និងឆេស (Chase) គឺជាការសន្និដ្ឋាននាំមុខមួយដែលថា DNA គឺជាធាតុផ្សំរបស់ហ្សែន។	khm_Khmr
+739	geography	The Cook Islands គឺជាប្រទេសកោះមួយដែលស្ថិត​ក្នុង​​សមាគមសេរី​​ជាមួយប្រទេសណូវែលសេឡង់ ដែលមានទីតាំងស្ថិតនៅ Polynesia នៅកណ្តាលមហាសមុទ្រប៉ាស៊ីហ្វិកខាងត្បូង។	khm_Khmr
+548	sports	Na mogarũrũku kuma harĩ gacunjĩ kamwe ka inya nginya nuthu ya mairo iteng'era, ihenya rĩtuikaga rĩa bata hanini na kũmĩrĩria gũgatuika kwa bata makĩria.	kik_Latn
+824	travel	Rora nĩ thabarĩ irĩkũ mũramati ũcio aragathĩrĩria, kana nĩ rũrenda-inĩ kana nĩ ndirica-inĩ ya nduka.	kik_Latn
+1628	geography	ũingĩ wa andũ wa taũni nene ya Vatican nĩ gũkuhĩrĩria magana manana. Nĩguo bũrũri mũnini mũno ũkoragwo na wĩyathi thĩ yothe na bũrũri ũrĩa ũrĩ andũ anini mũno.	kik_Latn
+1596	science/technology	Igerekania rĩrĩa rĩekĩtwo nĩ Hershey na Chae nĩ rĩarĩ rĩmwe rĩa mawoni atĩ DNA nĩ cietanĩtio na indo cia genes.	kik_Latn
+739	geography	Icigĩrĩra cia Cook nĩ bũrũri wa gĩcigĩrĩra ũnyitanĩirwo na njĩra ya kwĩyendera na New Zealand, ũrĩ thĩ-inĩ wa Polynesia, gatagatĩ-inĩ ka Mũhuro wa Iria rĩa Pacific.	kik_Latn
+548	sports	Mu mpinduka zo kuva ku isiganwa rya kimwe cya kane ujya kuri kimwe cya kabiri cya mayili, kwihangana bihinduka ihame ridakuka.	kin_Latn
+824	travel	Reba ni izihe ngendo icyo kigo kirimo guteza imbere, yaba ku rubuga cyangwa ahagaragarira ibyo bakora.	kin_Latn
+1628	geography	Abaturage b’Umujyi wa Vatikani bagera kuri 800. Ni cyo gihugu gito cyane cyigenga mu isi ndetse n’igihugu gituwe n’abaturage bake cyane.	kin_Latn
+1596	science/technology	Igerageza rya Herishey na Chase ryabaye kimwe mu byifuzonama by'ingenzi ko ADN yari igikoresho cy’ibimenyetso ndangakoko.	kin_Latn
+739	geography	Ibirwa bya Cook, ni igihugu cy’ikirwa mu bufatanye busesuye na New Zealand, giherereye muri Polineziya, hagati y’Inyanja ya Pasifike y’Amajyepfo.	kin_Latn
+548	sports	Чуркоодо бир чейректен жарым чакырымга өткөндө, ылдамдыктын маанилүүлүгү азайып, чыдамкайлык талашсыз зарылчылыкка айланат.	kir_Cyrl
+824	travel	Агенттин вебсайтта же дүкөн виртинасында кандай саякаттарды жарнамалап жатканын карап көрүңүз.	kir_Cyrl
+1628	geography	Ватикан шаарындагы калктын саны болжол менен 800 барабар. Ал дүйнөдөгү көз карандысыз эң кичине жана ошондой эле калкынын саны эң аз болгон өлкө.	kir_Cyrl
+1596	science/technology	ДНКнын генетикалык материал экендиги тууралуу биринчи сунуштардын бири — Херши жана Чейз эксперименти болгон.	kir_Cyrl
+739	geography	Кук аралдары – Түштүк Тынч океанынын борборунда жайгашкан Полинезиядагы Жаңы Зеландияга өз ыктыяры менен бириккен арал өлкөсү.	kir_Cyrl
+548	sports	Ni ubhilulukilu wa dixilu dimoxi phala o mbandu ya milya ya ulengelu, o lusolo lwadibhange ndenge ni nguzu yadibhange kiibindamu kya kinene-nene.	kmb_Latn
+824	travel	Talesa jinjila ja ungenj ala mu sumbisa, kikale mu kididi (site) mba mu diloja.	kmb_Latn
+1628	geography	Mundu wa mbanza ya Vaticano itenesa 800 ja atungidi. Yene ixi yasukuku mu ngongo mu kutola yala ni diphanda, ni athu atolo we.	kmb_Latn
+1596	science/technology	Masunga a Hershey ni Chase akexile athu abetelekota mu kuzwela kuma ADN yexile ima ya usambukilu wa ifwa ya jitata ku twana.	kmb_Latn
+739	geography	Ilhas Cook jibanga ixi ya kisangela ni Nova Zelandya, tuyisanga ku Polinesia, mukaxi ka musanzu wa Pacifico ya lwiji.	kmb_Latn
+548	sports	Gava ji bazdana çaryek mîlî derbasî bazdana nîvmîlî bûnê, giringîya lezê pirr bêtir kêm dibe û diberxwedayîn, dibe pêdivêyeke ku nebe, nabe.	kmr_Latn
+824	travel	Di sîteyeke webê de yan di pencereyeke pêşangehê de çav lê bigerînin ka nûner, teşwîqa we ya kîjan geştan dike.	kmr_Latn
+1628	geography	Nifûsa Bajarê Vatîkanê li dora 800î ye. Welatê azad ê herî piçûk ê Dinyayê û di heman demê de ê nifûsa wê herî kêm e.	kmr_Latn
+1596	science/technology	Tecrîbeya Hershey û Chase, yek ji pêşnîyaran bû ku DNA materyaleke genetîk e.	kmr_Latn
+739	geography	Giravên Cook welatekî giravan e ku bi Zelanda Nû, ya li Polînezyayê ya di nîvê Okyanûsa Pasîfîk a Başûr de, di têkiliyeke serbest de ye.	kmr_Latn
+548	sports	كور كصد فلتن رببلن سز رتر ولجن دوا دواتد شيم اودني محمم	knc_Arab
+824	travel	ونوي بلارو ناي كورنودين ما كالا واي ليا لان كلا او سورو بيرنيين يايه.	knc_Arab
+1628	geography	جما. 800 بلا بتكند مبزي، دنيلن لرد شرو غناؤ با، كمب غن	knc_Arab
+1596	science/technology	غودتو دوني حيرشي كور شيثيدي شيما شواري دوني بور سلككر دي ان اي DNA أولا فل الويي	knc_Arab
+739	geography	كرقويه كووك ديه بلا دو نيليفا باك ها نيوزليندا نا. بلا بلينيسي، داو كومودو آنووم ميه لان.	knc_Arab
+548	sports	Kwata milyelan reta milyero faltәlan, nәm doidә isә faida gana’aro waljin kuru loktu kuruwuro rangnәm kasodә zauro mәradәtәnaro waljin.	knc_Latn
+824	travel	Ngǝlaro wune bulawuro jiriyi shimbulawurobe dǝye dawarjin ro, nduwudunyaram men au window sanyaramzǝye men.	knc_Latn
+1628	geography	Adadu jama bәrni Vaticanbedә 800. Shima lardә naptә kәlanzәye zauro cilluwuma wo kuru lardә doni zauro am gana’a wo.	knc_Latn
+1596	science/technology	Kulashi Hershey-a Chase-abedә shima kazadalawo nasha DNA-dә shima alagә do shiro genetic material sainmawo.	knc_Latn
+739	geography	Cook Islands sodǝ lardǝ island ben New Zealand sowa kǝllata, na Polynesia be dǝn kara, dawu cece Kumodugu South Pacific ben.	knc_Latn
+548	sports	Na kukatuka na ndambu na iya (quart) mpi kukwenda na katikati ya kilometere, ntinu ke vandaka mfunu mingi ve kansi kukanda-ntina nde ke kumaka mfunu kuluta.	kon_Latn
+824	travel	Losa disu na wapi mutindu ya banzietelo bisadi me kukulula ntalu, ya vanda na site web to na ba fenetele ya ba nzo ba ke tekaka batike.	kon_Latn
+1628	geography	Bantu ya mbanza Vatican kele kiteso ya 800. Yo kele insi ya kulutila fyoti ya me bakaka kimpwanza na ntoto ya mvimba mpi yo kele insi ya kele ti bantu ya kulutila fyoti.	kon_Latn
+1596	science/technology	Nsosa ya Hershey na Chase vandaka mosi ya bansosa yina moniska nde AND vandaka kima ya bo ke butukaka ti yo.	kon_Latn
+739	geography	Bisanga ya Cook kele kisanga ya insi na kuwakana ya mpamba na kimvuka na Nouvelle Zelande, yai ya kele na Polynesie, na katikati ya Mbu ya Pacifique du Sud.	kon_Latn
+548	sports	달리는 거리를 사백 미터에서 팔백 미터로 바꾸니, 속도의 중요성은 약해지고 지구력이 절대적으로 필요하게 됩니다.	kor_Hang
+824	travel	웹사이트 또는 점포 게시물에서 여행 대행사가 어떤 여행을 홍보하고 있는지 살펴보세요.	kor_Hang
+1628	geography	바티칸 시국의 인구는 약 800명입니다. 세계에서 가장 작은 독립 국가이자 인구가 가장 적은 나라입니다.	kor_Hang
+1596	science/technology	허쉬와 체이스의 실험은 DNA가 유전적 물질이라고 제안한 선두 연구 중 하나였습니다.	kor_Hang
+739	geography	쿡 제도는 남태평양 한가운데 폴리네시아에 위치하며, 뉴질랜드와 자유연합을 맺은 섬 국가입니다.	kor_Hang
+548	sports	ດ້ວຍການປ່ຽນແປງຈາກການແລ່ນໜຶ່ງໃນສີ່ສ່ວນໄປສູ່ການແລ່ນເຄິ່ງໄມລ໌, ຄວາມໄວຈະກາຍເປັນຄວາມສຳຄັນໜ້ອຍ ແລະ ຄວາມອົດທົນກາຍເປັນຄວາມຈຳເປັນແທ້ໆ.	lao_Laoo
+824	travel	ທ່ານສາມາດກວດເບິ່ງການເດີນທາງທີ່ຕົວແທນທ່ອງທ່ຽວກຳລັງໂຄສະນາ ບໍ່ວ່າຈະເປັນໃນເວັບໄຊ ຫຼື ຢູ່ຕາມໜ້າຮ້ານ.	lao_Laoo
+1628	geography	ປະຊາກອນຂອງເມືອງວາຕິນກັນແມ່ນປະມານ 800 ຄົນ. ມັນແມ່ນປະເທດທີມີເອກະລາດນ້ອຍທີສຸດໃນໂລກ ແລະ ເປັນປະເທດທີມີປະຊາກອນໜ້ອຍທີ່ສຸດ.	lao_Laoo
+1596	science/technology	ການທົດລອງຂອງທ່ານ ເຮີຊີ່ (Hershey) ແລະ ທ່ານ ເຊສ໌ (Chase) ແມ່ນໜຶ່ງໃນບັນດາຂໍ້ສະເໜີແນະຊັ້ນນຳວ່າ ດີເອັນເອ (DNA) ແມ່ນ ສານພັນທຸກຳ.	lao_Laoo
+739	geography	ໝູ່ເກາະ Cook ແມ່ນປະເທດເກາະທີ່ບໍ່ຂຶ້ນກັບນິວຊີແລນ ເຊິ່ງຕັ້ງຢູ່ໃນ Polynesia ພາກກາງຂອງມະຫາສະໝຸດປາຊີຟິກຕອນໃຕ້.	lao_Laoo
+548	sports	Co-o passaggio da-o quarto de miggio a-a corsa de mezo miggio, a velocitæ a diventa ben ben meno importante e a rexistensa a diventa unna neçescitæ assolua.	lij_Latn
+824	travel	Danni unn’euggiâ à che viægi o l’è apreuvo à promeuve, segge in sciô scito web segge int’unna vedriña.	lij_Latn
+1628	geography	A popolaçion da Çittæ do Vatican al’è de circa 800 abitanti. o l’è o paise indipendente o ciù piccin a-o mondo e o paise co-a popolaçion minô.	lij_Latn
+1596	science/technology	L’esperimento Hershey e Chase o l’è stæto un di prinçipæ suggerimenti do fæto che o DNA o fïse un materiale genetico.	lij_Latn
+739	geography	E Isoe Cook son un stato de isoe in libera associaçion co-a Neuva Zelanda, ch’o sta in Polinesia, into mezo de l’Oceano Pacifico meridionale.	lij_Latn
+548	sports	Mèt de wissel vaan 400 nao 800 m weur snelheid minder belaankriek en oethawdingsvermoge absoluut noodzakelek.	lim_Latn
+824	travel	Kiek ‘ns nao wat ‘t reisbureau aon ‘t promote is op hun website of hun etalaasj.	lim_Latn
+1628	geography	De populatie vaan Vaticaanstad is oongeveer 800. ‘t Is ‘t kleinste oonaofhenkelek land in de wereld en ‘t land met de minste einwoeners.	lim_Latn
+1596	science/technology	‘t experimint vaan Hershey en Chase waor ein vaan de belaankriekste um to laote zien dat DNA genetisch mattriaol waor.	lim_Latn
+739	geography	De Cook eilande zien ‘ne eilandstaot in Polynesië in los associatie mèt Nui-Zieland, in ‘t midde vaan de Stèllen Oceaan.	lim_Latn
+548	sports	Lokola balongwaki na quart ya mbangu mpe bakomaki na demi-mile, vitese ekomaki ntina mingi te mpe kokanga motema ekomaki ntina mingi.	lin_Latn
+824	travel	Tala mibembo oyo mosali azopesa, ezala na site internet to na vitre ya fenetre.	lin_Latn
+1628	geography	Bato ya Engumba ya Vatican baza pene ya 800. Eza mboka ya koleka moko oyo ezwa lipanda na mokili pe mboka oyo eza ya bato moke koleka.	lin_Latn
+1596	science/technology	Makambo oyo Hershey na Chase bamekaki eza na kati ya makanisi ya ntina emonisi ete ADN ezalaki eloko ya makila.	lin_Latn
+739	geography	Bisanga Cook eza mokili ya kati ya esanga oyo eza na boyokani na bango moko na Nouvelle-Zélande, oyo eza na Polynésie, na katikati ya mbu ya Pacifique ya Sudi.	lin_Latn
+548	sports	Jei bėgama ne ketvirtį, o pusę mylios, greičio svarba sumažėja, o ištvermė tampa absoliučia būtinybe.	lit_Latn
+824	travel	Svetainėje ar vitrinoje peržiūrėkite, kokias keliones siūlo agentas.	lit_Latn
+1628	geography	Vatikano mieste yra apie 800 gyventojų. Tai yra mažiausia nepriklausoma valstybė pasaulyje, turinti mažiausiai gyventojų.	lit_Latn
+1596	science/technology	Hershey ir Chase eksperimentas buvo vienas iš svarbiausių siekiant įrodyti, kad DNR yra genetinė medžiaga.	lit_Latn
+739	geography	Kuko Salos yra salų šalis, esanti laisvojoje asociacijoje su Naująja Zelandija, ji yra Polinezijoje, pietinio Ramiojo vandenyno viduryje.	lit_Latn
+548	sports	Cul cambiamént de la corsa de un quart de mia a mèza mia, la velocità l’è pü inscì impurtanta e la resistenza la diventa la necessitaa püssè grànda.	lmo_Latn
+824	travel	Dàch n’ögiada ai viàgg che l’agént el püblicìza, sün del website o in de la vedrìna del negòzzi.	lmo_Latn
+1628	geography	La populaziùn de la Cità del Vatican l’è di circa 800 persùnn. L’è el paés indipendént püssé picùl del mùnd e el paés cun la populaziùn püssé bàsa.	lmo_Latn
+1596	science/technology	El esperimént de Hershey e Chase l’era vün di principài indìzi che el DNA l’era materiàl genetìch.	lmo_Latn
+739	geography	I Isùli Cook ienn un staa insülar in libéra associaziùn cunt la Növa Zelànda, chi se truuen in Polinesia, in del mèzz de l’Ucean Pacifich Meridiunàl.	lmo_Latn
+548	sports	Puoreimūt nu caturdaļjiudzis iz pusi nu jiudzis skriejīni, uotrums kliust mozuok svareigs, i iztureiba kliust par absolutu napīcīšameibu.	ltg_Latn
+824	travel	Apsaverit, kaidus ceļuojumus agents reklamej sātyslopā voi skotlūgā.	ltg_Latn
+1628	geography	Vatikana piļstātys īdzeivuotuoju skaits ir apmāram 800. Tei ir mozuokuo naatkareiguo vaļsts pasaulī i vaļsts ar mozuokū īdzeivuotuoju skaitu.	ltg_Latn
+1596	science/technology	Heršija i Čeisa eksperiments beja vīns nu vodūšajim īrūsynuojumim, ka DNS ir genetisks materials.	ltg_Latn
+739	geography	Kuka Solys ir solu vaļsts, kas ir breivā asociacejā ar Jaunzelandi i atsarūn Polinezejā, Klusuo okeana dīnvydu daļā.	ltg_Latn
+548	sports	Mam Wiessel vum Véierel- zum Hallefkilometerlaf verléiert Geschwindegkeet u Wichtegkeet an Ausdauer gëtt zur absolutter Noutwennegkeet.	ltz_Latn
+824	travel	Kuckt Iech un, wéi eng Reesen den Agent ubitt, sief et op sengem Internetsite oder an enger Butteksvitrinn.	ltz_Latn
+1628	geography	D'Vatikanstad zielt zirka 800 Awunner. Et ass dat klengst onofhängegt Land vun der Welt an dat Land mat der nidderegster Bevëlkerung.	ltz_Latn
+1596	science/technology	D'Hershey-an-Chase-Experiment war ee vun de féierende Virschléi, datt DNS e geneetescht Material wier.	ltz_Latn
+739	geography	D'Cookinsele sinn en Inselstaat a fräier Associatioun mat Neuseeland; se leien a Polynesien, matzen am Südpazifik.	ltz_Latn
+548	sports	Ne dishintuluka dia ku tshimua tshia binayi kuya ku ngatshingatshi wa ntanta wa luendu, lubilu ke ndua mujinga kabidi to ne dinanukila dikadi dia mushinga.	lua_Latn
+824	travel	Ela mesu ku ngendu kayi idi agent ufila, nyi mu site eshi mu victrine.	lua_Latn
+1628	geography	Bantu ba mu Vatican mbatue ku 800. Nka ditunga kakese ka pabuaku ka pa buloba ni ka ditunga ka bantu bakese.	lua_Latn
+1596	science/technology	Bena bulongame bua Hershey ne bena Chase bamanyi bapiluke badi bakubamue bafidi ba nganyi ne badi tshisumbu tshia ADN mumanyi ne batue lungenyi pa biamua ebi.	lua_Latn
+739	geography	Bidiila bia Cook bidi ditunga mu bulongolodi budikadidi ne Nouvelle-Zélande, mu Polynésie, mu nkatshi mua Mbuu wa Pasifike wa ku Sud.	lua_Latn
+548	sports	N'enkyukakyuka okuva mu kimu kya kuna okutuuka ku kitundu kya mayiro, sipiidi efuuka etali ya makulu nnyo era okuguma ne kufuuka ekyetaago ekya ddala.	lug_Latn
+824	travel	Tunuulila ngedo kki atambuza zatulaze eziliko, paka wansi kagwiilawo.	lug_Latn
+1628	geography	Vatican City kilimu abantu 800. Ke kasi akeefuga kokka akakyasinze obutono munsi yonna era ensi esinga abantu abatono.	lug_Latn
+1596	science/technology	Okugezesa kwa Hershey ne Chase byebimu ku byalaga nti endagabutonde eri mu musaayi gwa muntu	lug_Latn
+739	geography	Ekizinga bya Cook byansi etalina kakwate ku New Zealand ebisangibwa mu Polynesia mumasekati g’amaserengeta ga ssemayanja Pacific.	lug_Latn
+548	sports	Gi lokruok koa achiel ewi ang'wen nyaka nus mar mail e ringo, okang ng'wech bedo gi geno matin kendo tho dich bedo gi geno maduong'.	luo_Latn
+824	travel	Ng'i ane ni gin wuodhi mage ma jambetreno jiwo, bed ni ojiwogi gi ndiko e mbui kata gi oboke miyudo e duka.	luo_Latn
+1628	geography	Kwan mag ji modak e piny mar Vatican City nyalo romo ji 800. En e piny matin mogik mochung' kende e piny magima kendo ma nikod kwan matin mogik mag ji.	luo_Latn
+1596	science/technology	Nonro mar Hershey kod Chase gin achiel kuom gik mane ong'ado ni DNA ne en gir remo.	luo_Latn
+739	geography	Chula Mag Tedo gin Chula man kod riwruok man thuolo gi piny New Zealand, mantie Polynesia, dier pii man Pacific mamilambo.	luo_Latn
+548	sports	Mel hmun lia thena hmun khat tlanna atanga mel chanve tlana thleng a nih hnu chuan, tlanchak aiin tuarchher chu a pawimawh zawk ta a ni.	lus_Latn
+824	travel	Heng buaipuitute hian eng zin khawthawnna nge an fak deuh tih an website ah emaw shop window ah te en ang che.	lus_Latn
+1628	geography	Vatican City a mihring cheng zawng zawng hi mi zariat vel an ni. Khawvela ram te ber a ni a, mihring cheng awm tlemna ber a ni bawk.	lus_Latn
+1596	science/technology	Hershey leh Chase experiment chu DNA hi inthlachhawn na hmanrua (genetic material) a ni thei tih hmuchhuak tu pawimawh a ni.	lus_Latn
+739	geography	Cook Islands hi thliarkar awm khawm ram a ni a, New Zealand nen inkungkaihna tha tak nei, South Pacific Ocean-a Polynesia-a awm a ni.	lus_Latn
+548	sports	Skrējiena distancei pieaugot no ceturtdaļjūdzes līdz pusjūdzei, ātruma nozīme krietni samazinās un par absolūtu nepieciešamību kļūst izturība.	lvs_Latn
+824	travel	Apskatiet, kādus ceļojumus aģents reklamē tīmekļa vietnē vai veikala skatlogā.	lvs_Latn
+1628	geography	Vatikāna iedzīvotāju skaits ir ap 800. Tā ir mazākā neatkarīgā valsts pasaulē un valsts ar vismazāko iedzīvotāju skaitu.	lvs_Latn
+1596	science/technology	Heršija un Čeisa eksperiments bija viens no vadošajiem ierosinājumiem, ka DNS ir ģenētisks materiāls.	lvs_Latn
+739	geography	Kuka salas ir salu valsts, kas ir brīvā asociācijā ar Jaunzēlandi, atrodas Polinēzijā, Klusā okeāna dienvidu vidū.	lvs_Latn
+548	sports	क्वार्टर से आधे मील के दौड़ में बदलाव के साथ, गति बहुत कम महत्व के हो जा हय अउ धीरज बहुत जरुरी बन जा हय।	mag_Deva
+824	travel	एगो नज़र डाला कि एजेंट कोन यात्रा के प्रचार कर रहल हई, चाहे ऊ वेबसाइट पर होए चाहे दुकान के खिड़की पर।	mag_Deva
+1628	geography	वेटिकन सिटी के आबादी लगभग 800 हय। ई दुनिया के सबसे छोटा स्वतंत्र देश अउ सबसे कम आबादी वाला देश हय।	mag_Deva
+1596	science/technology	हर्शे अउ चेज़ प्रयोग प्रमुख सुझाव में से एगो हलय कि डीएनए एगो आनुवंशिक सामग्री हलय।	mag_Deva
+739	geography	कुक द्वीप दक्षिण प्रशांत महासागर के मध्य में, पोलिनेशिया में स्थित न्यूजीलैंड के साथे मुक्त सहयोग में एगो द्वीप देश हय।	mag_Deva
+548	sports	चौथाई सँ आधा मीलक दौड़ में बदलावक संग, गति बहुत कम महत्वक भए जैत अछि आ धीरज एकटा परम आवश्यकता बनि जैत अछि।	mai_Deva
+824	travel	कनी देखूं कि एजेंट कोन यात्रा सभक प्रचार कए रहल अछि, चाहे ओ वेबसाइट पर हुए या दुकानक खिड़की पर।	mai_Deva
+1628	geography	वेटिकन सिटीक आबादी लगभग 800 अछि। ई दुनियाक सब सं छोट स्वतंत्र देश आ सब स कम आबादी बला देश अछि।	mai_Deva
+1596	science/technology	हर्शे आ चेज़ प्रयोग प्रमुख सुझाव सभ में सँ एकटा छल कि DNA एकटा आनुवंशिक सामग्री छल।	mai_Deva
+739	geography	कुक आइलैंड्स दक्षिण प्रशांत महासागरक मध्य में, पोलिनेशिया में स्थित न्यूजीलैंडक संग मुक्त सहयोग में एकटा द्वीप देश अछि।	mai_Deva
+548	sports	കാല്‍ മൈൽ ഓട്ടത്തിൽ നിന്നും അര മൈൽ ഓട്ടത്തിലേക്ക് മാറുന്നതോടെ, വേഗതയ്ക്ക് വളരെ കുറച്ച് പ്രാധാന്യം ആവുകയും, സ്ഥിരത ഒരു നിരുപാധികമായ ആവശ്യകതയായി മാറുകയും ചെയ്യുന്നു.	mal_Mlym
+824	travel	ഒരു വെബ്‌സൈറ്റിലായാലും ഷോപ്പ് വിൻഡോയിലായാലും ഏജന്റ് ഏതൊക്കെ യാത്രകളാണ് പ്രോത്സാഹിപ്പിക്കുന്നതെന്ന് നോക്കുക.	mal_Mlym
+1628	geography	വത്തിക്കാൻ സിറ്റിയിലെ ജനസംഖ്യ ഏകദേശം 800 ആണ്.ഇതാണ് ലോകത്തിലെ ഏറ്റവും ചെറിയ സ്വതന്ത്ര രാജ്യവും ഒപ്പം ജനസംഖ്യ ഏറ്റവും കുറഞ്ഞ രാജ്യവും.	mal_Mlym
+1596	science/technology	ഹെർഷിയും ചേസും പരീക്ഷണം ഡിഎൻ‌എ 1 ജനിതക മെറ്റീരിയലാണെന്നുള്ള പ്രധാന നിർദ്ദേശങ്ങളിലൊന്നാണ്.	mal_Mlym
+739	geography	തെക്കൻ പസഫിക് സമുദ്ര മധ്യത്തിൽ, പോളിനേഷ്യയിൽ സ്ഥിതി ചെയ്യുന്ന, ന്യൂസിലാൻഡുമായി സ്വതന്ത്ര സഹകരണത്തിലുള്ള ഒരു ദ്വീപ രാജ്യമാണ് കുക്ക് ഐലൻഡ്സ്.	mal_Mlym
+548	sports	पाव मैल धावण्याऐवजी अर्धा मैल धावल्याने, वेगाचे महत्त्व कमी होते आणि सहनशक्ती सर्वात गरजेची ठरते.	mar_Deva
+824	travel	एजंट कोणत्या सहली प्रमोट करीत आहे ते पहा, एखाद्या वेबसाईट वर किंवा दुकान खिडकी मध्ये.	mar_Deva
+1628	geography	व्हॅटिकन शहराची लोकसंख्या सुमारे 800 आहे. हा जगातील सर्वात छोटा स्वतंत्र देश आणि सर्वात कमी लोकसंख्या असलेला देश आहे.	mar_Deva
+1596	science/technology	हर्शे आणि चेस प्रयोग अग्रगण्य सूचनांपैकी 1 होता की डीएनए अनुवांशिक द्रव्य होते.	mar_Deva
+739	geography	कूक बेटे हा न्यूझीलंड शी मुक्त सहसंबध असणारा एक बेटांचा देश आहे, जो पॉलीनेशिया मध्ये, दक्षिण प्रशांत महासागराच्या मध्यभागी स्थित आहे.	mar_Deva
+548	sports	ديک ڤاروباهأن لاري دري ساڤارمڤق ك ساتاڠه ميل، كاكنچاڠن منجادي کورڠ ڤارالو ساراتو دايو تاهن منجادي سابوءه كابوتوهن مطلق.	min_Arab
+824	travel	ڤاراتيكنله ڤاجالانن اڤو نن اݢين تو ڤروموسيكن، انته د سيتوسڽو اتاو د جندلا توكوڽو.	min_Arab
+1628	geography	ڤندودوءق کوتا ۏاتيکن باجومله كيرو-كيرو ٨٠٠ اورڠ۔ ايكو ادوله نݢارا مردك ڤاليڠ کيتيق د دونيا جو نݢارا نن ممڤوڽو ڤندودوءق ڤاليڠ ساكتك.	min_Arab
+1596	science/technology	اوجي چوبو هرشهي جو چهاسي ادوله ساله ساتو ڤنداڤق تاكاموكو باسو دن ادوله باهن نن باهوبوڠن جو كاتورونن.	min_Arab
+739	geography	كاڤولااءوءن چووق ادوله ناݢارا كاڤولااءوءن نن باڬابوءڠ ساچارو اندق تاءيكق جو سلنديا بارو، تمڤكڽو بارادو د ڤولينسي، ديتاڠه سمودرا ڤاسيفيک سالاتن.	min_Arab
+548	sports	Dek parubahaan lari dari saparampek ka satangah mil, kakancangan manjadi kurang paralu sarato dayo tahan manjadi sabuah kabutuhan mutlak.	min_Latn
+824	travel	Paratikanlah pajalanan apo nan agen tu promosikan, antah di situsnyo atau di jandela tokonyo.	min_Latn
+1628	geography	Panduduak kota Vatikan bajumlah kiro-kiro 800 urang. Iko adolah negara mardeka paliang ketek di dunia jo negara nan mampunyoi panduduak paliang saketek.	min_Latn
+1596	science/technology	Uji cubo Hershey jo Chase adolah salah satu pandapek takamuko baso DNA adolah bahan nan bahubungan jo katurunan.	min_Latn
+739	geography	Kapulauan Cook adolah nagara kapulauan nan bagabuang sacaro indak taikek jo Selandia Baru, tampeknyo barado di Polinesia, ditangah samudera Pasifik Salatan.	min_Latn
+548	sports	Со промена на трката од четвртина во половина милја, брзината станува многу помалку важна, а издржливоста станува апсолутна неопходност.	mkd_Cyrl
+824	travel	Погледнете какви патувања промовира агенцијата, без разлика дали е на веб-локација или на излог.	mkd_Cyrl
+1628	geography	Популацијата на Ватикан е околу 800 луѓе. Таа е најмалата независна држава во светот и држава со најмалку популација.	mkd_Cyrl
+1596	science/technology	Експериментот на Херши и Чејс беше една од водечките претпоставки дека ДНК е генетски материјал.	mkd_Cyrl
+739	geography	Куковите Острови се островска земја во слободно здружување со Нов Зеланд, лоцирана во Полинезија, во средината на Јужниот Тихи Океан.	mkd_Cyrl
+548	sports	Bil-bidla mill-ġirja ta' kwart ta' mil għal dik ta' nofs mil, il-veloċità ssir inqas importanti u l-kapaċità li wieħed jirreżisti ssir meħtieġa b'mod assolut.	mlt_Latn
+824	travel	Agħti ħarsa lejn liema vjaġġi qed jippromwovi l-aġent, kemm jekk fuq sit web jew f’vetrina ta’ ħanut.	mlt_Latn
+1628	geography	Il-popolazzjoni tal-Belt tal-Vatikan hija ta' madwar 800. Hija l-iżgħar pajjiż indipendenti fid-dinja u l-pajjiż bl-inqas popolazzjoni.	mlt_Latn
+1596	science/technology	L-esperiment ta’ Hershey u Chase kien wieħed mis-suġġerimenti ewlenin li d-DNA kien materjal ġenetiku.	mlt_Latn
+739	geography	Il-Gżejjer Cook huma pajjiż ta’ gżejjer f’assoċjazzjoni ħielsa ma’ New Zealand, li jinsabu fil-Polineżja, f’nofs l-Oċean Paċifiku tan-Nofsinhar.	mlt_Latn
+548	sports	ক্বার্তরদগীনা মাইল তংখাই ফাওবা চেনবদা লাকপা অহোংবা অসিদা, খোংজেল হায়বসিগী মতিক হন্থরকই অদুগা এন্দ্যুরেন্স (হনবা লৈতবা) হায়বসিনা খ্বাইদগী মরু ওইবা অমা ওইরকই।	mni_Beng
+824	travel	এজেন্ত অদুনা প্রোমোৎ তৌরিবা ত্রিপ অদু ৱেবসাইৎ অমদুগী নৎত্রগা শো ৱিন্দো অমদগী য়েংথোক্কদবনি।	mni_Beng
+1628	geography	ভেতিকান সিতীগী মীশিং অসি চাউরাক্না 800নি।মসি মালেমগী খ্বাইদগী পীকপা মনিং-মখা তম্বা লৈবাক্নি অমসুং মীশিং খ্বাইদগী য়ামদনা লৈবা লৈবাক্নি।	mni_Beng
+1596	science/technology	 হার্শেই অমসুং চেজ চাংয়েং হায়বসি DNAবু জিনেতিক ওইবা পোৎশক অমনি হায়না তাকখিবা মকোকচিংবা সজেসনশিংগী মনুংদা অমা ওইখি।	mni_Beng
+739	geography	কুক ঈথৎ অসি সাউথ পেসিফিক ওসীনগী ময়াওদা পোলিনেসিয়াদা লৈবা ন্যু জীলেন্দগা ফ্রি এসোসিএসন্দা লৈরিবা ঈথৎকী লৈবাক অমনি।	mni_Beng
+548	sports	Tusr zĩis-a naasa pʋɩɩs zug bɩ tusra pʋsʋk zugu, tao-tao wã zoees ka le waoog ye tɩ bilf-bilfa zoees lebg tilae.	mos_Latn
+824	travel	Modg n bãnge so-toak bog buudu la f moonde, tɩ ya ub sita zugu maa ub tʋʋma zĩigẽ.	mos_Latn
+1628	geography	Vatican soolemin wan ninbouida sonr ta 800. Ya andouni wan tibil ninga sin tara a soogueminga.	mos_Latn
+1596	science/technology	A Hershey la Chase bãngra yɩɩ koss kasẽng sẽn kẽed ne bũmb ning sẽn wilgd tɩ ADN yaa bũmb sẽn yaa yĩnga meng bũmbu.	mos_Latn
+739	geography	Riib seglsa ko-gũb-tẽnsa yaa ko-gũb-tẽng n tar naagr-taab zaale ne Nouvelle-Zélande tẽnga n bee Polynésie soolma pʋga la bee Pacifique mog-ma goabg baobgo pusuke.	mos_Latn
+548	sports	I runga i te panoni atu i te omanga hauwhā maero ki te haurua, ka iti iho te hiranga o te tere, ka noho mātua waiwai te manawa piharau.	mri_Latn
+824	travel	Tirohia atu ki ngā haerenga e whakatairangatia ana e ngā kaiwhakahaere, mā te pae tukutuku, mā te matapihi rānei o te toa.	mri_Latn
+1628	geography	Tata ki te 800 te taupori o Vatican City. Koirā te whenua motuhake iti rawa o te ao, waihoki ko te whenua he iti rawa te taupori.	mri_Latn
+1596	science/technology	Ko te whakamātautau Hershey me Chase tētahi o ngā whakaaro i whakatau ai he mea ira te pītau ira.	mri_Latn
+739	geography	Ko ngā Kuki Airini tētahi whenua motu e wātea ana te pāheko ki Aotearoa, kei Poronihia, ki waenga tonu i te South Pacific Ocean.	mri_Latn
+548	sports	တစ်မိုင်၏ လေးပုံသုံးပုံမှ မိုင်ဝက်သို့ ပြောင်းလဲသည့် အပြေးပွဲတွင် အမြန်နှုန်းထက် ခံနိုင်ရည်မှာ အရေးအကြီးဆုံး ဖြစ်လာသည်။	mya_Mymr
+824	travel	အေးဂျင့် အရောင်းမြှင့်တင်ရေးလုပ်နေသောခရီးစဉ်များမှာ ဝဘ်ဆိုက် သို့မဟုတ် ဆိုင်၏ပြသသည့်နေရာတွင် ရှိ မရှိ တစ်ချက်ကြည့်ကြည့်ပါ။	mya_Mymr
+1628	geography	Vatican City ၏လူဦးရေမှာ ၈၀၀ ဝန်းကျင်ရှိပါသည်။ ၎င်းသည် ကမ္ဘာပေါ်တွင် အသေးဆုံးသော လွတ်လပ်သည့်နိုင်ငံဖြစ်ကာ လူဦးရေအနည်းဆုံးနိုင်ငံလည်းဖြစ်ပါသည်။	mya_Mymr
+1596	science/technology	ဟာရှေး နှင့် ချေ့စ် စမ်းသပ်မှုများတွင် DNA သည် မျိုးဗီဇဆိုင်ရာပစ္စည်းဖြစ်ကြောင်းမှာ အထင်ကရယူဆချက်များအနက် တစ်ခုဖြစ်ခဲ့ပါသည်။	mya_Mymr
+739	geography	ကွက်ခ်ကျွန်းများသည် တောင်ပစိဖိတ် သမုဒ္ဒရာ၏ အလယ်ရှိ ပိုလီနီးရှားတွင် တည်ရှိပြီး နယူးဇီလန်နှင့် လွတ်လပ်စွာ နှီးနွှယ်နေသော ကျွန်းနိုင်ငံတစ်ခု ဖြစ်သည်။	mya_Mymr
+548	sports	Nu de run geen kwart mijl, maar een halve mijl is, gaat het minder om snelheid en veel meer om uithoudingsvermogen.	nld_Latn
+824	travel	Kijk eens welke reizen de agent promoot, op een website of in de etalage.	nld_Latn
+1628	geography	Er wonen circa 800 inwoners in Vaticaanstad. Dit is het kleinste onafhankelijke land op de hele wereld en ook het land met het laagste bevolkingsaantal.	nld_Latn
+1596	science/technology	Het experiment van Hershey en Chase was een van de belangrijkste aanwijzingen dat DNA een genetisch materiaal was.	nld_Latn
+739	geography	De Cookeilanden is een land van eilanden in vrije associatie met Nieuw-Zeeland. De eilanden zijn gelegen in Polynesië, middenin de zuidelijke Stille Oceaan.	nld_Latn
+548	sports	Når løpet blir endra frå 400 meter til 800 meter, blir fart mykje mindre viktig, mens uthald blir heilt essensielt.	nno_Latn
+824	travel	Ta en kikk på kva for turar reisebyrået reklamerer for, enten det er på ei nettside eller i eit butikkvindauge.	nno_Latn
+1628	geography	Vatikanstaten har eit folketal på rundt 800. Det er det minste sjølvstendige staten i verda med det lågaste folketalet.	nno_Latn
+1596	science/technology	Hershey- og Chase-eksperimentet var ein av dei leiande teoriane om at DNA var eit genetisk materiale.	nno_Latn
+739	geography	Cookøyane er ein sjølvstyrt øystat som er tilknytt New Zealand og ligg i Polynesia, midt i det sørlege Stillehavet.	nno_Latn
+548	sports	Med endringen fra 400 til 800 meter, har hastigheten blitt av mindre betydning, mens utholdenhet er en absolutt nødvendighet.	nob_Latn
+824	travel	Sjekk hvilke turer agenten anbefaler, enten på nettsiden eller i butikkvinduet.	nob_Latn
+1628	geography	Befolkningen i Vatikanet er på ca. 800. Det er det minste selvstendige landet i verden og landet med den laveste befolkningen.	nob_Latn
+1596	science/technology	Hershey og Chase-eksperimentet var et av de fremste forslagene som påsto at DNA kunne være et genetisk materiale.	nob_Latn
+739	geography	Cook-øyene er et øyrike lokalisert i Polynesia, midt i det sørlige Stillehavet, som har fri tilknytning til New Zealand.	nob_Latn
+548	sports	एक चौथाइ माइलको दौडबाट आधा माइलको दौडमा परिवर्तन हुँदा दौडने गति त्यति धेरै महत्त्वपूर्ण हुँदैन र धैर्यता अत्यन्तै महत्त्वपूर्ण हुन्छ।	npi_Deva
+824	travel	एजेन्टले वेबसाइटमा होस् वा पसलको सन्झ्यालमा कस्ता ट्रिपहरूको प्रचार गरिरहेको छ हेर्नुहोस्।	npi_Deva
+1628	geography	भ्याटिकन सिटीको जनसङ्ख्या करिब 800 जति छ। यो विश्वको सबैभन्दा सानो स्वतन्त्र देश र सबैभन्दा कम जनसङ्ख्या भएको देश हो।	npi_Deva
+1596	science/technology	डीएनए आनुवंशिक सामग्री थियो भनेर Hershey र Chase प्रयोग अग्रणी सुझाव थिए।	npi_Deva
+739	geography	दक्षिण प्रशान्त महासागरको बिचमा पोलिनेसियामा अवस्थित न्यूजील्यान्डको स्वतन्त्रतामा सहकार्य गर्ने कुक द्वितहरू हुन्‌।	npi_Deva
+548	sports	ߝߏ߬ߣߌ߫ ߦߟߍ߬ߡߊ߲߫ ߘߌ߫ ߞߍ߫ ߞߊ߬ ߓߐ߫ ߜߟߊ߬ߜߟߊ߫ ߄߀߀ ߘߐ߫ ߞߊ߬ ߦߟߍ߬ ߈߀߀ ߘߐ߫߸ ߓߏ߬ߙߌ߬ߝߊ߲ߞߊ ߞߎ߬ߘߎߜߟߍ߬ߦߊ ߘߌ߫ ߘߐߝߍ߲߯ߦߊ߫ ߸ ߞߊ߬ ߕߊ߬ߡߌ߲߬ ߡߊ߲߬ߕߙߐ ߞߎ߲ߠߌ߲ ߡߊߣߐ߬ ߟߊ߫.	nqo_Nkoo
+824	travel	ߌ ߢߊ ߟߊߕߊ߬ߡߌ߲߬ ߕߊ߯ߡߊߘߐߕߊ߮ ߟߎ߫ ߞߊ߲߬ ߖߋ߬ߕߌ߰ߘߊ ߦߋ߫ ߡߍ߲ ߠߎ߬ ߛߘߊߟߊ߫ ߟߊ߫ ߸ ߏ߬ ߞߍ߫ ߘߊ߫ ߞߍߦߙߐ߫ ߢߎߡߍߙߋ߲ߡߊ ߛߌߟߊ ߝߍ߬ ߓߊ߬ ߸ ߥߟߊ߫ ߖߊ߬ߥߏ߬ߘߊ ߢߍߕߐ߫ ߘߎߡߊ ߟߎ߬ ߞߣߐ߫.	nqo_Nkoo
+1628	geography	ߝ߭ߊߕߌߞߊ߲߫ ߛߏ ߛߌ߰ߓߊ߮ ߦߙߌߞߊ ߦߋ߫ ߡߐ߰ ߈߀߀ ߠߋ߬ ߘߌ߫. ߊ߬ߟߋ ߟߋ߬ ߘߍ߲ߒߖߘߍߟߊ߫ ߖߡߊߣߊ ߓߍ߯ ߘߐ߫ ߞߏߘߋߞߏߘߋ ߘߌ߫ ߘߎߢߊ߫ ߞߣߐ߫ ߸ ߊ߬ ߣߴߊ߬ ߓߍ߯ ߘߐ߫ ߛߌ߰ߓߊ߮ ߦߙߌߞߊ߫ ߘߐ߯ߡߊ߲ ߘߌ߫.	nqo_Nkoo
+1596	science/technology	ߤߊߙߑߛߋߦߌ߫ ߣߌ߫ ߛ߭ߊߛߌ߫ ߟߊ߫ ߞߘߐߓߐߟߌ ߟߋ߬ ߞߍ߫ ߘߊ߫ ߦߌ߬ߘߊ߬ߞߏ߬ ߞߟߏߡߊ ߟߎ߬ ߘߏ߫ ߟߋ߬ ߘߌ߫ ߞߏ߫ ߛߌߢߋ߬ߟߋ (ߛ ߢ ADN) ߟߋ߬ ߗߍߕߊߢߐ߲߯ߦߊ ߖߐ߯ߙߊ߲ ߘߌ߫.	nqo_Nkoo
+739	geography	ߞߎߞ ߕߌ߲ߥߙߍ ߦߋ߫ ߞߊ߬ߝߏ߬ ߞߊ߲ߠߊߓߌ߬ߟߊߣߍ߲ ߠߋ߬ ߘߌ߫ ߣߋߦߎ-ߖ߭ߋߟߊ߲ߘ ߘߍ߭ ߞߣߐ߫ ߸ ߡߍ߲ ߡߊߞߍߣߍ߲߫ ߖߐ ߟߌ߲ߓߊ߲ ߥߙߏ߬ߘߎ߮ ߕߍߡߊ߬ ߔߏߟߌߣߋߗ߭ߌ߫.	nqo_Nkoo
+548	sports	Ka phetogo ya go tšwa go kotara go ya go go kitima ga seripa sa mile, lebelo ga e sa le selo se bohlokwa gomme kgotlelelo e ba hloko ya go felelela.	nso_Latn
+824	travel	Lebelela gore ke maeto afe ao moemedi a a godišago, e kaba wepesaeteng goba lesthikangopeng la lebenkele.	nso_Latn
+1628	geography	Badudi ba Motse wa Vatican ba ka ba ba le 800. Ke naga ye nnyane ya go ikema lefaseng gomme le naga ya batho ba nomoro ya fasefase.	nso_Latn
+1596	science/technology	Teko ya Hershey le Chase e be e le yengwe ya ditšhišinyo tša go etapele tša gore DNA e be e le karolwana ya leabela.	nso_Latn
+739	geography	Dihlakahlaka tša Cook ke naga ya sehlakahlaka ya go ba le kamano ya go lokologa le New Zealand, e hwetšwa Polynesia, gare ga Lewatle la Borwa bja Pacific.	nso_Latn
+548	sports	Kɛ gër ni̱ kä kɛl wi̱ic kä ŋuaan ɛwä ni̱ kä nuth kuɛɛni̱ kɛɛ themdɛ,ɛla wuɔ̱rɛ thiɛlɛ jɛ luɔt kä dhiëlɛ tëëkɛ luɔt mi̱ di̱i̱t.	nus_Latn
+824	travel	Ŋäcni̱ tin la̱tkɛ ɛ naath tin la̱a̱t guäth thurbiɛli guäth in la kɛn läärikiɛn ɛ tho̱p kɛ jɛ.	nus_Latn
+1628	geography	Pe̱k rɛɛk  ji̱ we̱c in cɔali̱ Batikan ɛ 800. Ɛjɛn we̱c in kuiyni̱ jɛn in ci̱ kumɛ dɛ je̱k wi̱i̱muɔ̱n kä ɛjɛn we̱c in kuiy ni̱ ji̱kɛ.	nus_Latn
+1596	science/technology	Ɣɛn He̱rcɛy kɛnɛ Ciɛth mëë ci̱ kɛn ɛ ɣɔ̱n kɛ lät ni̱ ɛjɛn mëë ci̱ të nhiam kɛ ɣöö larɛ jɛ i̱ DNA ɛ duŋ gi̱i̱nä.	nus_Latn
+739	geography	Kɛn dhuɔ̱ɔ̱li̱ Kuuk kɛɛ dhuɔ̱ɔ̱l mi̱ rɛk min te̱e̱ kɛɛl kɛɛ Ni̱e̱w Dhi̱i̱lɛn min te̱ kä Pölini̱thia. däär jɔak ɣɔaa kä bäbdiit pa̱ci̱pik.	nus_Latn
+548	sports	Ndikusintha kothamanga kuchokera pa kota mayilosi mpaka theka la mayilo, liwiro silimakhala lofunikira kwambiri koma kupilira ndiko kumafunika kwenikweni.	nya_Latn
+824	travel	Onanai maulendo amene mkhalapakati akulimbikitsa, kaya pa tsamba la intaneti kapena pawindo la shopu.	nya_Latn
+1628	geography	Chiwelengero cha anthu m'mzinda wa Vatican ndi pafupifupi 800. Ndi dziko laling'ono lodziyilira palokha komanso dziko la anthu ochepa kwambiri.	nya_Latn
+1596	science/technology	Kafukufuku wa Hershey ndi Chase adali m'modzi mwa maganizo otsogolera kuti DNA idali chibadwa.	nya_Latn
+739	geography	Dziko la Cook ndi la zilumba limene limagwirizana mopanda kukamizidwa ndi dziko la New Zealand, lomwe lili ku Polynesia, pakati pa Nyanja yamchere ya Pacific.	nya_Latn
+548	sports	Amb lo cambiament de corsa del quart a la mièja mila, la velocitat ven d’una importància mendra e l’endurança ven una necessitat absoluda.	oci_Latn
+824	travel	Getatz un còp d'uèlh als viatges que l'agent presenta, que siá sus un sit web o a la veirina d'una botiga.	oci_Latn
+1628	geography	La populacion de la Ciutat de Vatican es a l’entorn de 800 personas. Es lo país independent mai petit del mond entièr e lo país qu'a la populacion mai febla.	oci_Latn
+1596	science/technology	L'experiéncia de Hershey e Chase foguèt una de las suggestions principalas que l'ADN èra un material genetic.	oci_Latn
+739	geography	Las Islas Cook son un país insular liurament associat amb Nòva Zelanda, situat en Polinesia, al mitan del sud de l'Ocean Pacific.	oci_Latn
+548	sports	ଦୌଡର ଦୂରତା ଚଉଠ ମାଇଲରୁ ବଢି ଅଧା ମାଇଲ୍ ହେଲେ, ବେଗ ବହୁତ କମ୍ ଗୁରୁତ୍ଵ ବହୁତପୂର୍ଣ୍ଣ ହୁଏ ଏବଂ ସହିବାର କ୍ଷମତା ଅପରିହାର୍ଯ୍ୟ ହୋଇଯାଏ।	ory_Orya
+824	travel	ୱେବସାଇଟ୍ କିମ୍ବା ଦୋକାନ ୱିଣ୍ଡୋରେ ଏଜେଣ୍ଟ କେଉଁ ଯାତାୟତକୁ ପ୍ରୋତ୍ସାହିତ କରୁଛନ୍ତି ତାହା ଉପରେ ନଜର ପକାନ୍ତୁ।	ory_Orya
+1628	geography	ଭାଟିକାନ୍ ସିଟିର ଜନସଂଖ୍ୟା ପ୍ରାୟ 800। ଏହା ବିଶ୍ୱର ସବୁଠାରୁ ଛୋଟ ସ୍ୱାଧୀନ ଦେଶ ଏବଂ ସର୍ବନିମ୍ନ ଜନସଂଖ୍ୟା ବିଶିଷ୍ଟ ଦେଶ।	ory_Orya
+1596	science/technology	ହର୍ଷେ ଏବଂ ଚେଜ୍ ପରୀକ୍ଷଣର ଏକ ମୁଖ୍ୟ ପ୍ରସ୍ତାବ ଥିଲା କି DNA 1 ଆନୁବଂଶିକ ତତ୍ତ୍ୱ।	ory_Orya
+739	geography	କୁକ୍ ଦ୍ୱୀପପୁଞ୍ଜ ଦକ୍ଷିଣ ପ୍ରଶାନ୍ତ ମହାସାଗରର ମଧ୍ୟଭାଗରେ ପଲିନେସିଆରେ ଅବସ୍ଥିତ, ନ୍ୟୁଜିଲ୍ୟାଣ୍ଡ ସହିତ ମୁକ୍ତ ଭାବରେ ଜଡିତ ଏକ ଦ୍ୱୀପ ଦେଶ ଅଟେ।	ory_Orya
+548	sports	Manlapud kapeles na batik ya kakapat ya magmaliw ya ya kapalduan milya, diad satan et agla masyadon importante so kapeles, noagta say inkapaot la so manunan kaukolan.	pag_Latn
+824	travel	Nengnengen no antoray partikular ya promotion na saray agent,diad website odino shop window.	pag_Latn
+1628	geography	Say Vatican city so walaay 800 ya population.Sankamelagan iyan syudad ed mundo tan sankaraisitan na totoo.	pag_Latn
+1596	science/technology	Say eksperimento nen Hershey tan Chase so sakey ed saray manunan suhestion ya say DNA et atawir.	pag_Latn
+739	geography	Say Cook Islands et sakey ya bansa walad isla ya bulos ya makakaonla ed New Zealand, wala iyad Polynesia, diad pegley na South Pacific Ocean.	pag_Latn
+548	sports	ਪੰਦਰਾ ਮਿੰਟ ਤੋਂ ਅੱਧਾ ਘੰਟੇ ਦੀ ਦੌੜ ਵਿੱਚ ਬਦਲਾਵ ਨਾਲ, ਗਤਿ ਦਾ ਮਹੱਤਵ ਘੱਟ ਜਾਂਦਾ ਹੈ ਅਤੇ ਧੀਰਜ ਇੱਕ ਪੂਰਨ ਲੋੜ ਬਣ ਜਾਂਦਾ ਹੈ।	pan_Guru
+824	travel	ਇਕ ਨਜ਼ਰ ਮਾਰੋ ਕਿ ਏਜੰਟ ਵੈਬਸਾਈਟ ਤੇ ਜਾਂ ਦੁਕਾਨ ਵਿੱਚ ਕਿੱਥੋਂ ਦੀ ਯਾਤਰਾ ਨੂੰ ਉਤਸ਼ਾਹਿਤ ਕਰ ਰਿਹਾ ਹੈ ।	pan_Guru
+1628	geography	ਵੈਟੀਕਨ ਸ਼ਹਿਰ ਦੀ ਜਨਸੰਖਿਆ ਲਗਪਗ 800 ਹੈ। ਇਹ ਸੰਸਾਰ ਵਿੱਚ ਸਭਤੋਂ ਘੱਟ ਵੱਸੋਂ ਵਾਲਾ ਸਭਤੋਂ ਛੋਟਾ ਸੁਤੰਤਰ ਦੇਸ਼ ਹੈ।	pan_Guru
+1596	science/technology	ਹਰਸ਼ੀ ਅਤੇ ਚੇਜ਼ ਪ੍ਰਯੋਗ ਦੇ ਕਈ ਪ੍ਰਮੁੱਖ ਸੁਝਾਵਾਂ ਵਿੱਚੋਂ ਇੱਕ ਇਹ ਸੀ, ਕਿ ਡੀ.ਐਨ.ਏ. ਇੱਕ ਜੈਨੇਟਿਕ ਵਸਤੂ ਹੈੈ।	pan_Guru
+739	geography	ਕੁੱਕ ਆਈਲੈਂਡਜ਼ ਦੱਖਣੀ ਪ੍ਰਸ਼ਾਂਤ ਮਹਾਂਸਾਗਰ ਦੇ ਮੱਧ ਵਿੱਚ ਪੋਲੀਨੇਸ਼ੀਆ ਵਿੱਚ ਸਥਿਤ ਨਿਊਜ਼ੀਲੈਂਡ ਤੋਂ ਸੁਤੰਤਰ ਇੱਕ ਆਈਲੈਂਡ ਦੇਸ਼ ਹੈ।	pan_Guru
+548	sports	Ku e kambio di e kareda di un kuart pa mitar mia, velosidat ta bira di hopi ménos importansia i resistensia ta bira un nesesidat apsoluto.	pap_Latn
+824	travel	Tira un bista riba kua biahenan e agente ta promové, sea ta riba un wèpsait òf den e bentana di e negoshi.	pap_Latn
+1628	geography	Siudat di Vatikano su poblashon ta alrededor di 800. Ta e pais independiente di mas chikí na mundu i e pais ku e poblashon di mas abou.	pap_Latn
+1596	science/technology	E eksperimento di Hershey i Chase tabata un di e sugerensianan prinsipal ku ADN tabata un material genétiko.	pap_Latn
+739	geography	Cook Islands ta un nashon di isla asosiá libremente ku Nueva Zelandia, lokalisá na Polinesia, meimei di Oséano Pasífiko Sùit.	pap_Latn
+548	sports	د ربع څخه تر نیم ميله منډه وهلو پورې د بدلون سره، سرعت خورا لږ اهمیت لري او زغم یو مطلق ضرورت جوړيږي.	pbt_Arab
+824	travel	وګوره چې کوم یو سفر ته ایجنټ وده ورکوي هغه که په ويب سايټ وي او که د دوکان به کړکي کې	pbt_Arab
+1628	geography	د واټیکان ښار ابادي 800 ده. دا په نړۍ کې تر ټولو ورکوټی ازاد هېواد دی او تر ټولو لږه ابادي لرونکی هېواد دی.	pbt_Arab
+1596	science/technology	د هرشی او چېس تجربه هغه راهنمايي اشاره وه چې ډي این اې جینیاتي مواد دی.	pbt_Arab
+739	geography	د کوک جزیری یو جزیروي هیواد دي چې د نوي زیلاند سره وړیا تړلی دي ، په پولینیزا کې موقعیت لري د جنوبی ارام سمندر په منځ کې واقع دي	pbt_Arab
+548	sports	با تغییر از دوی یک چهارم مایل به نیم مایل، سرعت از اهمیت بسیار کمتری برخوردار می شود و استقامت به یک ضرورت مطلق تبدیل می شود.	pes_Arab
+824	travel	نگاهی بیندازید که در وب‌سایت یا در پنجره فروشگاه چه سفرهایی را تبلیغ می‌کند.	pes_Arab
+1628	geography	جمعیت شهر واتیکان حدود 800 نفر است. کوچکترین کشور مستقل در جهان است و نیز کمترین جمعیت در بین کشورها را دارد.	pes_Arab
+1596	science/technology	آزمایش Hershey و Chase یکی از پیشروترین اشارات به ژنتیکی بودن DNA بود.	pes_Arab
+739	geography	جزایر کوک یک کشور جزیره‌ای در اتحاد آزاد با نیوزلند است، که در پولینزی، در میانه اقیانوس آرام جنوبی واقع شده است.	pes_Arab
+548	sports	Miaraka amin’ny fiovan’ny hazakazaka avy any amin’ny ampahefany mankany amin’ny antsasaka mile, tsy zava-dehibe intsony ny hafainganampandeha ary ny faharetana no lasa ilaina indrindra.	plt_Latn
+824	travel	Asio maso ireo fitsangatsanganana misy fihenam-bidy, na eo amin’ny tranonkala izany na eo amin’ny fitaratry ny fivarotana.	plt_Latn
+1628	geography	Manodidina ny 800 ny mponina ao amin’ny tanànan’i Vatican. Izy no firenena mahaleo tena kely indrindra eto ambonin’ny tany ary izy koa no firenena manana mponina vitsy indrindra.	plt_Latn
+1596	science/technology	Ilay fanandramana nataon’i Hershey sy Chase no anisan’ny nahatonga ny olona hanatsoaka hevitra hoe zavatra ao amin’ny fototarazo ny ADN.	plt_Latn
+739	geography	Ny Nosy Cook dia nosy firenena anatin’ny fikambanana malalaka miaraka amin’ny Novely Zelandy, hita any Polinezia, eo ampovoan’ny Ranomasimbe Pasifika Atsimo.	plt_Latn
+548	sports	Gdy dystans biegu zmienia się z jednej czwartej na pół mili, szybkość traci na znaczeniu, a wytrzymałość staje się bezwzględną koniecznością.	pol_Latn
+824	travel	Sprawdź wycieczki promowane przez agenta na stronie internetowej lub w witrynie sklepu.	pol_Latn
+1628	geography	Populacja Watykanu liczy ok. 800 osób. Jest to najmniejsze niepodległe państwo na świecie, a także kraj o najmniejszej liczbie ludności.	pol_Latn
+1596	science/technology	Eksperyment Hersheya i Chase stanowił jedną z wiodących sugestii, że DNA było materiałem genetycznym.	pol_Latn
+739	geography	Wyspy Cooka to kraj wyspiarski pozostający w wolnym stowarzyszeniu z Nową Zelandią. Położone są w Polinezji w centralnej części południowego Pacyfiku.	pol_Latn
+548	sports	Com a mudança do percurso – de quarto de milha para meia milha –, a velocidade torna-se menos importante, e a resistência torna-se uma necessidade indispensável.	por_Latn
+824	travel	Veja quais pacotes o agente está promovendo, seja no site ou na vitrine da agência.	por_Latn
+1628	geography	A população da Cidade do Vaticano tem cerca de 800 pessoas. É o menor país independente do mundo, e com a menor população.	por_Latn
+1596	science/technology	O experimento de Hershey e Chase foi um dos principais indicadores de que o DNA era um material genético.	por_Latn
+739	geography	As Ilhas Cook são um país insular livremente associado à Nova Zelândia, localizado na Polinésia, no meio do Pacífico Sul.	por_Latn
+548	sports	با تغییر دوش ربع مایل به نیم مایل، سرعت اهمیت بسیار کمتری پیدا میکند و استقامت به ضرورتی مطلق تبدیل می شود.	prs_Arab
+824	travel	به سفرهای تبلیغی آژانس، در ویب سایت و در ویترین دکان نگاهی بیندازید.	prs_Arab
+1628	geography	جمعیت شهر واتیکان در حدود 800 نفر می باشد. واتیکان کوچکترین کشور مستقل در جهان و کشوری با کمترین جمعیت است.	prs_Arab
+1596	science/technology	یکی از پیشنهادات پیشرو درباره اینکه DNA یک ماده ژنتیکی است، آزمایش هرشی و چیس (Hershey و Chase) بود.	prs_Arab
+739	geography	جزایر کوک کشوری جزیره ای در معاشرت آزاد با نیوزلند، واقع در پلینزی، وسط اقیانوس آرام جنوبی است.	prs_Arab
+548	sports	Paway huk cuarto de milla nisqa huk kuchkan milla nisqaman, utqay kayta pisiyanmi imayna atipaqman hina lliw kallpachaqmanmi tukupun.	quy_Latn
+824	travel	Huk qawariyta quriy puriq agente promosionachkan chayta, ichapas web kitimanta utaq qawanamantapas.	quy_Latn
+1628	geography	Varicanuq Hatun llaqtanqa yaqapas 800 runakunayuqmi, huchuy kacharisqa llaqta llapan tiqsimuyumanta, pisi runayuq llaqta ima.	quy_Latn
+1596	science/technology	Hersheypa, Chasepa ima ruwasqankus kasqa qapaq niykuna ADN material genético kasqanmanta.	quy_Latn
+739	geography	Kook Watakuna wata suyuman kachkasqanku qispiy huñunasqa Nueva Zelandawan, Polinesiapi, Pacifico Mama Quchaq chawpinpi qullasuyupi hina.	quy_Latn
+548	sports	Odată cu trecerea de la cursa de un sfert la cea de jumătate de milă, viteza devine mult mai puțin importantă, iar rezistența devine o necesitate absolută.	ron_Latn
+824	travel	Aruncă o privire la excursiile pe cale le promovează agentul, pe un website sau pe fereastra unui magazin.	ron_Latn
+1628	geography	Populația Cetății Vaticanului este în jur de 800 de persoane. Este cea mai mică țară independentă din lume și țara cu cea mai mică populație.	ron_Latn
+1596	science/technology	Experimentul lui Hershey și Chase a reprezentat una dintre cele mai importante dovezi în favoarea ipotezei ADN-ul este material genetic.	ron_Latn
+739	geography	Insulele Cook sunt o țară insulară, asociată ca stat liber cu Noua Zeelandă, situată în Polinezia, în mijlocul Pacificului de Sud.	ron_Latn
+548	sports	Kubera ihinduka ryo kuva ku metero amajana ane baja ku metero amajana umunani, umuvuduko ntuba ugikenewe cane ahubwo haba hakenewe kwihangana hanyuma ukagumizako.	run_Latn
+824	travel	Tereza akajisho ku rubuga rwabo canke kw'idirisha ry'aho bakorera, urabe ingendo bahayanisha.	run_Latn
+1628	geography	Igisagara ca Vatikani igife abantu bababa 800 bakibamwo. Nico gihugu gito ca mbere c’igenga kw'isi kandi nico gihugu gifise abantu bake.	run_Latn
+1596	science/technology	Ubushakashatsi bwa Hershey na Chase ni kimwe muntererazo zerekanye ko ADN ari selile ikoze umuntu.	run_Latn
+739	geography	Amazinga ya Cook ni igihugu co mu mazi gifitaniye na Nouvelle Zélande ubucuti burimwo ukwidegemvya, kikaba kiri muri Polynésie, hagati mw'ibahari Pasifike yo mu Bumanuko.	run_Latn
+548	sports	Если увеличить расстояние для бега с четверти до половины мили, скорость становится не так важна, тогда как выносливость превращается в абсолютную необходимость.	rus_Cyrl
+824	travel	Посмотрите, какие поездки рекламирует агент, на сайте или на витрине офиса.	rus_Cyrl
+1628	geography	Население Ватикана составляет около 800 человек. Это самая маленькая независимая страна в мире, а также страна, имеющая наименьшее население.	rus_Cyrl
+1596	science/technology	Эксперимент  Херши и Чейз был одним из первых предположений, что ДНК является генетическим материалом.	rus_Cyrl
+739	geography	Острова Кука – это островное государство, состоящее в свободной ассоциации с Новой Зеландией, находящейся в Полинезии в центре южной части Тихого океана.	rus_Cyrl
+548	sports	Na hongo ti ti quart na demi-mile, loro ni a ga mingi pepe na sarango ngangu a ga ye so ayeke ti nzoni.	sag_Latn
+824	travel	Ala za le ti ala na aguengo gene zo ti ndokua ti kusara lo fa ni, wala na site Web wala na ndo ti fango asango.	sag_Latn
+1628	geography	Azo ti kodoro ti Cité ti Vatican hungo ti ala a ga nduru na 800. ayeke kete kodoro ti dipanda na ya dunia nga kodoro so a zo ayeke da gba ni pepe.	sag_Latn
+1596	science/technology	Nda ye Hershey na Chase ayeke oko ti a ta unda ngo ye ti fa atene ADN a yeke mbeni gbakuru ti a ye ti tere ti zo.	sag_Latn
+739	geography	Azua ti Cook ayeke kodoro so agongbi na Nouvelle-Zélande, ayeke na ndo ti Polynésie, na bê ti ngu ingo ti pacifique ti mbongo.	sag_Latn
+548	sports	सपादमीलतः सार्धमीलपर्यन्तं धावनात् जाते परिवर्तने, वेगस्य महत्त्वं न्यूनीभवति तथा च क्षान्तिः परमावश्यकता भवति।	san_Deva
+824	travel	एकं दृष्टं प्रयोगं करतु यः एजेंट किम् यात्रानां प्रचारः करोति, यद्यपि इदं वेबसाइटे एवं आपणस्य वातानुकुले भवति ।	san_Deva
+1628	geography	Vatican नगरस्य जनसङ्ख्या प्रायः 800 मिता अस्ति। एषः जगति लघुतमः स्वतन्त्रः देशः अस्ति तथा च लघुतमजनसङ्ख्यायुतः देशः अपि अस्ति।	san_Deva
+1596	science/technology	DNA जनुकीयसामग्रीः अस्ति इति प्रामुख्येन सूचयत्सु प्रयोगोषु एकः आसीत् हर्षीअँडचेसप्रयोगः।	san_Deva
+739	geography	कुक द्वीपः दक्षिण प्रशांत महासागरस्य मध्ये, पोलिनेशियायाम् स्थित न्यूजीलैंडस्य सह मुक्त सहयोगे एक द्वीप देशः भवति ।	san_Deva
+548	sports	ᱠᱚᱣᱟᱴᱟᱨ ᱠᱷᱚᱱ ᱦᱟᱯᱷ ᱢᱟᱭᱤᱞ ᱫᱟᱹᱲ ᱨᱮ, ᱛᱟᱹᱯᱤᱥ ᱟᱹᱰᱤ ᱠᱚᱢ ᱢᱚᱦᱚᱛᱟᱱ ᱦᱩᱭᱩᱜᱼᱟ ᱟᱨ ᱥᱟᱦᱟᱣ ᱫᱟᱲᱮ ᱮᱠᱟᱞ ᱞᱟᱹᱠᱛᱤᱭᱟᱱᱟᱜ ᱵᱮᱱᱟᱜᱼᱟ᱾	sat_Olck
+824	travel	ᱢᱩᱫ ᱱᱚᱡᱚᱨ ᱮᱢ ᱠᱟᱛᱷᱟ ᱡᱮ ᱮᱡᱮᱸᱴ ᱫᱚ ᱚᱠᱟ ᱴᱨᱤᱯ ᱠᱚ ᱢᱚᱱᱮᱭᱟᱜ ᱠᱟᱱᱟᱭ, ᱢᱮᱱᱠᱷᱟᱱ ᱡᱟᱦᱟᱸ ᱣᱮᱵᱥᱟᱭᱤᱴ ᱟᱨ ᱵᱟᱝ ᱫᱚᱠᱟᱱ ᱡᱷᱚᱨᱠᱟ ᱨᱮ᱾	sat_Olck
+1628	geography	ᱵᱷᱟᱴᱤᱠᱟᱱ ᱥᱤᱴᱤ ᱨᱮᱭᱟᱜ ᱦᱚᱲ ᱞᱮᱠᱷᱟ ᱫᱚ ᱘᱐᱐ ᱜᱟᱱᱟ᱾ ᱱᱚᱶᱟ ᱫᱚ ᱡᱮᱜᱮᱛ ᱨᱮ ᱡᱷᱚᱛᱚ ᱠᱷᱚᱱ ᱠᱟᱹᱴᱤᱡ ᱟᱹᱯᱱᱟᱹᱛ ᱫᱤᱥᱚᱢ ᱠᱟᱱᱟ ᱟᱨ ᱱᱟᱥᱮ ᱦᱚᱲ ᱞᱮᱠᱦᱟ ᱩᱛᱟᱹᱨ ᱫᱤᱥᱚᱢ ᱠᱟᱱᱟ᱾	sat_Olck
+1596	science/technology	ᱦᱟᱹᱨᱥ ᱟᱨ ᱪᱮᱥ ᱯᱨᱚᱭᱚᱜᱽ ᱫᱚ ᱯᱨᱚᱢᱤᱠᱷ ᱥᱩᱡᱷᱟᱹᱣ ᱠᱷᱚᱱ ᱢᱤᱫᱴᱟᱹᱝ ᱛᱟᱦᱮᱸ ᱠᱟᱱᱟ ᱡᱮ ᱰᱤᱹᱮᱱᱹᱮᱹ ᱢᱤᱫᱴᱟᱹᱝ ᱚᱱᱩᱵᱚᱝᱥᱤᱠ ᱡᱤᱱᱤᱥ ᱛᱟᱦᱮᱸ ᱠᱟᱱᱟ᱾	sat_Olck
+739	geography	ᱫᱩᱠᱷᱤᱱ ᱯᱮᱥᱤᱯᱷᱤᱠ ᱫᱚᱨᱭᱟ ᱛᱟᱞᱟᱨᱮᱭᱟᱜ ᱯᱳᱞᱤᱱᱮᱥᱤᱭᱟ ᱨᱮᱭᱟᱜ ᱠᱳᱠ‌ ᱫᱤᱯ ᱫᱚ ᱱᱤᱭᱩᱡᱽ ᱞᱟᱸᱰ ᱥᱟᱶ ᱯᱷᱨᱤ ᱟᱥᱳᱥᱤᱭᱮᱥᱚᱱ ᱨᱮ ᱢᱤᱫ ᱫᱤᱯ ᱫᱤᱥᱚᱢ ᱠᱟᱱᱟ᱾	sat_Olck
+548	sports	Canciannu la cursa di un quartu di migghiu a menzu migghiu, la vilucità addiventa menu mpurtanti e la risistenza addiventa na nicissità.	scn_Latn
+824	travel	Talìa li viaggi urganizzati di l’aggenti, ncapu ô situ web o ntâ putija.	scn_Latn
+1628	geography	La pupulazzioni dâ Città dû Vaticanu è di circa 800 abbitanti. È lu pajisi nnipendenti cchiù nicu dû munnu e lu pajisi cu cchiù picca pupulazzioni.	scn_Latn
+1596	science/technology	Lu spirimentu di Hershey e Chase fu na nsinuazzioni granni ca lu DNA era matiriali ginèticu.	scn_Latn
+739	geography	L’ìsuli Cook sunnu allazzati puliticamenti â Nova Zilanna e si tròvanu nnâ Pulinesia, nta l’Uceanu Sud Pacìficu.	scn_Latn
+548	sports	သင်ဝႃႈလႆႈလႅၵ်ႈလၢႆႈၵၢၼ်လႅၼ်ႈၶေႉၼႂ်းၶၢဝ်းတၢင်း0.25 လၵ်း (400m.) မႃးပဵၼ်ၵၢၼ်လႅၼ်ႈၶေႉၶိုင်ႈလၵ်း (800m.) ၼႆၼၼ်ႉ တၢင်းၽႂ်းၼၼ်ႉဢမ်ႇလွင်ႈယႂ်ႇပဵင်းလွင်ႈယိူၼ်ႉၵၼ်ႈ ဢၼ်ပဵၼ်လွင်ႈဢၼ်တၵ်းလူဝ်ႇလႆႈမီး ၼၼ်ႉယူႇယဝ်ႉ။	shn_Mymr
+824	travel	တူၺ်းၸိူဝ်း ပဵၼ်တူဝ်တႅၼ်းတီႈ ယုၵ်ႉမုၼ်းဢမ်ႇဝႃႈတေပဵၼ်ၼိူဝ် ဝႅပ်ႉလႄႈ တၢင်းၼႃႈတၢင်ႇလၢၼ်ႉၸိူဝ်းၼၼ်ႉလႄႈ ဝႃႈ ၶဝ်ယုၵ်ႉမုၼ်းသင်ယူႇ။	shn_Mymr
+1628	geography	ႁူဝ်ၼပ်ႉၵူၼ်း ဝဵင်း Vatican ၼႆႉ မီးႁိမ်းႁွမ်း 800 ၵေႃႉ ။ မၼ်းပဵၼ်မိူင်းလွတ်ႈလႅဝ်း ဢၼ်လဵၵ်ႉသေပိူၼ်ႈၼႂ်းလူၵ်ႈ လႄႈ ဝၢၼ်ႈမိူင်းဢၼ်ႁူဝ်ၼပ်ႉၵူၼ်းဢေႇသေပိူၼ်ႈယဝ်ႉ။	shn_Mymr
+1596	science/technology	ၵၢၼ်ၶူၼ်ႉၶႂႃႉ Hershey လႄႈ Hershey ၼႆႉ ပဵၼ်ပိူင်လူင် လွင်ႈပၼ်တၢင်းဝူၼ်ႉ လွင်ႈဝႃႈ DNA ပဵၼ်ၶူဝ်းၶွင် ၵဵဝ်ႇလူၺ်ႈၸိူဝ်ႉၽၼ်းပီႇၸႃႉ(genetic material) ဢၼ်ၼိုင်ႈၼႆ။	shn_Mymr
+739	geography	ၵုၼ် Cook ၸိူဝ်းၼႆႉပဵၼ် ဝၢၼ်ႈမိူင်းဢၼ်ပဵၼ်ၵုၼ် ဢၼ်ဢမ်ႇမီးလွင်ႈၵပ်းၵၢႆႇၵၼ်တၢင်း မိူင်း New Zealand၊ မီးတီႈလႅၼ်လိၼ် Polynesia၊ တီႈၼႂ်းၵၢင်ပၢင်ႇလၢႆႇ  Pacific ပွတ်းၸၢၼ်းၼၼ်ႉယဝ်ႉ။	shn_Mymr
+548	sports	ධාවන දුර සැතපුම් කාලක සිට භාගය දක්වා වෙනස් වෙද් දී, වේගයට ලැබෙන්නේ අඩු වැදගත්කමක් වන අතර, දැරීමේ ශක්තිය අත්‍යවශ්‍ය අවශ්‍යතාවක් බවට පත්වේ.	sin_Sinh
+824	travel	වෙබ් අඩවියක හෝ සාප්පු කවුළුවක වුවත්, නියෝජිතයා ප්‍රවර්ධනය කරන සංචාර මොනවාදැයි බලන්න.	sin_Sinh
+1628	geography	වතිකානු නගරයේ ජනගහනය ආසන්න වශයෙන් 800 කි. එය ලෝකයේ කුඩාම සහ අඩුම ජනගහනයෙන් යුත් රටයි.	sin_Sinh
+1596	science/technology	ඩීඑන්ඒ යනු ජානමය ද්‍රව්‍යයක් බව කියවෙන යෝජනා වලින් ප්‍රධානතම එකක් වූයේ හර්ෂේ සහ චේස් ගේ අත්හදා බැලීමයි.	sin_Sinh
+739	geography	කුක් දූපත් යනු දකුණු පැසිෆික් සාගරය මධ්‍යයේ පොලිනීසියාවෙහි ඇති, නවසීලන්තය සමඟ නිදහස් සම්බන්ධතාවක් පවත්වන දූපත් රටකි.	sin_Sinh
+548	sports	Pri prechode z behu na štvrť míle na beh na pol míle sa rýchlosť stáva oveľa menej dôležitou a vytrvalosť absolútne nevyhnutnou.	slk_Latn
+824	travel	Pozrite sa, aké zájazdy agentúra ponúka, či už na jej webe alebo vo výklade.	slk_Latn
+1628	geography	Vatikán má asi 800 obyvateľov. Je to najmenší suverénny štát na svete s najnižším počtom obyvateľov.	slk_Latn
+1596	science/technology	Experiment vykonaný Hersheyom a Chasem patril medzi hlavné príznaky, že DNA je genetický materiál.	slk_Latn
+739	geography	Cookove ostrovy sú ostrovným štátom, ktorý je vo voľnom zväzku s Novým Zélandom a nachádza sa v Polynézii uprostred južného Tichého oceánu.	slk_Latn
+548	sports	Ko iz teka na četrt milje prestopiš na tek na pol milje, postane hitrost precej manj pomembna, vzdržljivost pa brezpogojno obvezna.	slv_Latn
+824	travel	Na spletnem mestu ali v izložbi preverite, katera potovanja, ki jih ponuja agencija, so znižana.	slv_Latn
+1628	geography	Vatikan ima približno 800 prebivalcev. Je najmanjša neodvisna država na svetu in država z najmanjšim številom prebivalcev.	slv_Latn
+1596	science/technology	Poskus Hershey in Chase je bil eden od glavnih namigov, da je DNK genetski material.	slv_Latn
+739	geography	Cookovi otoki so otoška država v prosti zvezi z Novo Zelandijo, ki se nahajajo v Polineziji, na sredini Južnega Tihega oceana.	slv_Latn
+548	sports	I le suiga mai le kuata i le afa maila o le tamo’e, o le saosaoa ua leai se taūa tele ma fetaia’iga ma faigata ua avea ma se mea e fa’ataūaina.	smo_Latn
+824	travel	Vaavaai po o a malaga o lo o fa’alauiloaina e le ofisa malaga, a le o le ‘upega tafa’ilagi po o totonu i se fa’amalama o se fale’oloa.	smo_Latn
+1628	geography	O le faitau aofa’i o tagata o le taulaga o Vatikana pe a ma le 800. O le atunuu tuto’atasi e pito i sili ona la’ititi i le lalolagi ma sili ona maulalo lona faitau aofa’i.	smo_Latn
+1596	science/technology	O fa’atinoga o su’esu’ega a Hershey ma Chase o se tasi o tusitusiga na taulamua o le DNA o se mea tau kenera.	smo_Latn
+739	geography	O le Atu Kuki o ni motu e iai sootaga sa’oloto ma Ni’u Sila, e i le Polenisia i le ogatotonu o le Vasa Pasefika i Saute.	smo_Latn
+548	sports	Nekushanduka kwemujaho wekumhanya kubva kukota kusvika kuhafu yemaira, kumhanya zvakanyanya hakuna kukosha asi kutsungirira kunobva kwakoshesesa zvikuru.	sna_Latn
+824	travel	Ongorora kuti ndedzipi nzendo dziri kushambadzwa nemunhu wacho, pangava paindaneti kana kuti pamahwindo echitoro.	sna_Latn
+1628	geography	Vatican City ine vanhu vanosvika mazana masere. Ndiyo nyika dikisa yakazvimiririra pasi rose uye nyika ine vanhu vashoma kupfuura dzimwe dzese.	sna_Latn
+1596	science/technology	Ongororo yeHershey naChase yaive imwe yemazano yakatungamira kuti DNA yaive nechekuita nemaumbirwo emunhu.	sna_Latn
+739	geography	Zvitsuwi zveCook inyika yezvitsuwi ine wirirano yakasununguka neNew Zealand, zvichiwanikwa kuPolynesia, pakati pegungwa reSouth Pacific.	sna_Latn
+548	sports	چوٿين کان اڌ ميل فاصلي تي تبديلي سان، رفتار تمام گهٽ اهم ٿي وئي ۽ پائيداري هڪ مڪمل ضرورت بڻجي ويندي آهي.	snd_Arab
+824	travel	هڪ نظر هڻو تہ ايجنٽ ويب سائيٽ يا دڪان تي ڪهڙي تفريحي سفر کي فروغ ڏيئي رهيو آهي.	snd_Arab
+1628	geography	ويٽيڪن شهر جي آبادي 800 جي لڳ ڀڳ آهي. هي دنيا جو سڀ کان ننڍو آزاد ملڪ ۽ گهٽ آبادي وارو ملڪ آهي.	snd_Arab
+1596	science/technology	هرشي ۽ چيز جو تجربو انهن اهم تصورن مان هڪ هو تہ DNA هڪ جينياتي مواد آهي.	snd_Arab
+739	geography	ڪوڪ ٻيٽ نيوزي لينڊ سان گڏ هڪ آزاد لاڳاپي ۾ هڪ ٻيٽ وارو ملڪ آهي، جيڪو ڏکڻ پئسفڪ سمنڊ جي وچ پولي نيسيا ۾ آهي.	snd_Arab
+548	sports	Markii laga bedeshay orodka mayl badhkiis ah, muhiimadii xawaaruhu aad bay u yaraatay adkaysigaana noqday baahi biyo kuma dhibcaan ah.	som_Latn
+824	travel	Fiirso safarada wakiilku ku xayaysiinayo websayd ama daaqadda dukaanka.	som_Latn
+1628	geography	Tirada dadka Magaalada Faatigaan waa ilaa 800. Waa waddanka ugu yare e xorta ah isla markaana ugu dadka yar adduunka.	som_Latn
+1596	science/technology	Tijaabada Hershey iyo Chase ayaa ah hor galayaasha ugu muhiimsana ee soo jeedintii in DNA ay tahay shey jinetik ah.	som_Latn
+739	geography	Jasiiradaha Cook waa waddan jasiiradeed si xor ah ula xiriira New Zealand, kuna yaalla Polynesia, kuna dhex yaalla Koonfurta Badwaynta Baasifigga.	som_Latn
+548	sports	Ka phetoho ya ho matha ho tloha ho kotara ho ya ho halofo ya mile, lebelo le fetoha le seng bohlokwa hakaalo mme mamello e fetoha se hlokahalang haholo.	sot_Latn
+824	travel	Sheba hore ke maeto a feng ao mohlophisi a a kgothalletsang, e ka ba websaeteng kapa fensetereng ya lebenkele.	sot_Latn
+1628	geography	Baahi ba Toropo ya Vatican ke ba ka bang 800. Ke naha e ikemetseng e nyenyane ho feta tsohle lefatsheng le naha e nang le baahi ba banyenyane lafatsheng lohle.	sot_Latn
+1596	science/technology	Teko ya Hershey le Chase ke e nngwe ya ditlhahiso tse etellang pele tsa hore DNA ke diphatsa tsa lefutso.	sot_Latn
+739	geography	Dihlekehleke tsa Cook ke naha ya sehlekehleke e ikamahantseng ka boithatelo le New Zealand, tse leng Polynesia, bohareng ba Lewatle le Leholo la Pacific le ka Borwa.	sot_Latn
+548	sports	Al producirse el cambio de la carrera de un cuarto a media milla, la velocidad pierde en gran medida su importancia, mientras que la resistencia se torna absolutamente necesaria.	spa_Latn
+824	travel	Consulte los viajes promocionados por el agente. Puede hacerlo en una página web tanto como en el escaparate de un negocio.	spa_Latn
+1628	geography	Con aproximadamente 800 habitantes, la Ciudad del Vaticano es el país independiente más pequeño del mundo y el de menor población.	spa_Latn
+1596	science/technology	Uno de los indicadores clave de que el ADN consistía en un material de tipo genético fue el experimento conducido por Hershey y Chase.	spa_Latn
+739	geography	Las Islas Cook, en Polinesia, Océano Pacífico, constituyen un estado insular en asociación voluntaria con Nueva Zelanda.	spa_Latn
+548	sports	Cun su càmbiu dae su cuartu a sa metade de mìgliu de cursa, sa velotzidade est divènnida prus pagu de importu e sa resistèntzia est divènnida una netzessidade assoluta.	srd_Latn
+824	travel	Pòmpia sos biazos chi s’agente l’est faghende publitzidade, siat in unu situ ìnternet siat in una vetrina.	srd_Latn
+1628	geography	Sa populatzione de sa Tzitade de su Vaticanu est prus o mancu de 800 persones. Est su paisu indipendente prus piticu in su mundu e cussu cun sa populatzione prus bassa.	srd_Latn
+1596	science/technology	S’esperimentu de Hershey e Chase est istadu unu de sos cussìgios printzipales ca su DNA est materiale genèticu.	srd_Latn
+739	geography	Sas ìsulas Cook sunt unu paisu ìsula in assòtziu lìberu cun sa Noa Zelanda, collacadas in Polinesia, e in mesu de s’Otzèanu Patzìficu de su sud.	srd_Latn
+548	sports	Повећавањем раздаљине са четвртине на пола миље, брзина почиње да игра много мању улогу, а издржљивост постаје апсолутно неопходна.	srp_Cyrl
+824	travel	Погледајте која путовања агент промовише, било на веб локацији, било у излогу.	srp_Cyrl
+1628	geography	Ватикан има око 800 становника. То је најмања независна држава на свету и држава са најмањим бројем становника.	srp_Cyrl
+1596	science/technology	Херши-Чејс експеримент је био један од водећих показатеља да је ДНК генетски материјал.	srp_Cyrl
+739	geography	Кукова острва су острвска земља која је у слободном савезу са Новим Зеландом, налазе се у Полинезији, у сред јужног Пацифика.	srp_Cyrl
+548	sports	Ngalolushintjo kusuka ekugijimeni libanga leliyikota kuya ekugijimeni libanga lelinguhhafu, litubane liba yintfo lengasiyo lebaluleke kangako futsi kubeketela kuba ngiyo intfo lebalulekile.	ssw_Latn
+824	travel	Buka kutsi nguluphi luhambo lomdayisi layilukhulumelako, nobe kuwebusayithi nobe efasitelweni lesitolo.	ssw_Latn
+1628	geography	Bantfu labahlala e-Vatican City balinganiselwa ema-800. Ilive lelincane kulatimele emhlabeni, futsi lelive linesibalo lesiphansi sebantfu.	ssw_Latn
+1596	science/technology	Luhlolo lwaHershey naChase belingulokunye kusikisela lokuhamba embili kwekutsi iDNA iyintfo yelufuto.	ssw_Latn
+739	geography	Lesichingi saseCook sichingi selive lesisebentisana neNew Zealand, sitfolakala ePolynesia, phakatsi neNingizimu yeLulwandle lwasePacific.	ssw_Latn
+548	sports	Kusabab parobahan jarak lumpat ti saparapat ka satengh mil, gancang janten teu pati penting sareng daya tahan anu janten kabutuhan mutlak.	sun_Latn
+824	travel	Tingali kana perjalanan naon nu agén promosikeun, dina situs wéb atawa dina jandela toko.	sun_Latn
+1628	geography	Populasi Vatican City nyaeta kira-kira 800 nyawa. Vatican nagara merdeka pangleutikna di dunya jeung nagara jeung populasi paling saeutik.	sun_Latn
+1596	science/technology	Eksperimen The Hersheydan Chase salah sahiji panalungtikan anu ngungkapkeun margi DNA nyaeta materi genetik.	sun_Latn
+739	geography	Kapuloan Cook mangrupikeun nagara pulo anu boga hubungan bébas jeung Selandia Baru, lokasina di Polinesia, di tengah Sagara Pasifik Kidul.	sun_Latn
+548	sports	Med ändringen från en kvarts till en halv engelsk mils löpning blir farten mycket mindre viktig och uthållighet blir en absolut nödvändighet.	swe_Latn
+824	travel	Ta en titt på vilka resor agenten marknadsför, vare sig de finns på en webbplats eller i ett skyltfönster.	swe_Latn
+1628	geography	Vatikanstaten har omkring 800 invånare. Det är världens minsta självständiga land och det land som har lägst antal invånare.	swe_Latn
+1596	science/technology	Hershey-Chase-experimentet var en av de främsta antydningarna om att DNA var ett genetiskt material.	swe_Latn
+739	geography	Cooköarna är ett öland fritt förbundet med Nya Zeeland, beläget i Polynesien, mitt i södra Stilla havet.	swe_Latn
+548	sports	Kwa mabadiliko kutoka mbio za robo hadi nusu maili, kasi huwa yenye umuhimu mdogo zaidi na ustahimilivu ukawa hitaji lenye umuhimu kabisa.	swh_Latn
+824	travel	Angalia ni safari zipi ambazo wakala anapendekeza, iwe kwenye tovuti au kwenye dirisha la duka.	swh_Latn
+1628	geography	Idadi ya watu Jijini Vatican ni takriban 800. Ndio taifa ndogo kabisa duniani lililo huru na nchi yenye idadi ndogo kabisa ya watu.	swh_Latn
+1596	science/technology	Jaribio la Hershey na Chase lilikuwa mojawapo ya mapendekezo kwamba DNA ilikuwa nyenzo za nasaba.	swh_Latn
+739	geography	Visiwa vya Cook ni nchi ya kisiwa katika ushirika huru na Nyuzilandi, iliyoko Polynesia, katikati mwa Bahari la Pasifiki ya Kusini.	swh_Latn
+548	sports	Z przejściym z lotanio na sztwierć do lotanio na pōł mile, wartkość stowo sie dużo mynij ważno, a wydzierżałość stowo sie absolutnōm kōniecznościōm.	szl_Latn
+824	travel	Przijzdrzij sie, jake ausflugi prōmuje agynt, czy to na strōnie internetowyj, abo szaufynstrze.	szl_Latn
+1628	geography	Populacyjo Watykanu wynosi kole 800 ôsōb. Je to nojmyńsze niyznoleżne państwo na świecie i kroj ô nojniższyj liczbie ludności.	szl_Latn
+1596	science/technology	Eksperymynt Hersheya i Chase'a bōł jednōm z wiedōncych sugestyji, iże DNA je materyjōm gynetycznōm.	szl_Latn
+739	geography	Wyspy Cooka to państwo wyspiorske we swobodnym zwiōnzku z Nowōm Zelandyjōm, położōne w Polinezyji, w postrzodkowyj tajli połedniowego Ôceanu Spokojnego.	szl_Latn
+548	sports	காலாண்டில் இருந்து அரை மைல் ஓட்டத்திற்கு மாற்றுவதன் மூலம், வேகம் மிகவும் குறைவான முக்கியத்துவம் பெறுகிறது மற்றும் சகிப்புத்தன்மை ஒரு முழுமையான தேவையாகிறது.	tam_Taml
+824	travel	ஒரு வலைத்தளத்திலோ அல்லது கடை விண்டோவிலோ முகவர் எந்த பயணங்களை ஊக்குவிக்கிறார் என்பதைப் காணுங்கள்.	tam_Taml
+1628	geography	வாடிகன் நகரின் மக்கள் தொகை சுமார் 800 ஆகும். இது உலகிலேயே மிகக் குறைந்த மக்கள் தொகை கொண்ட மிகச் சிறிய சுதந்திர நாடாகும்.	tam_Taml
+1596	science/technology	DNA என்பது ஒரு மரபணு பொருள் என்பதற்கான முக்கிய பரிந்துரைகளில் ஒன்று ஹெர்ஷே மற்றும் சேஸ் சோதனை.	tam_Taml
+739	geography	குக் தீவுகள் நியூசிலாந்தோடு கட்டற்ற இணைப்பு கொண்ட ஒரு தீவு நாடு, இது தென் பசிபிக் பெருங்கடலின் நடுவில் உள்ள பாலினீசியாவில் அமைந்துள்ளது.	tam_Taml
+548	sports	Asuki n tan kuẓ ar taẓuni, ahal yeqqel war yenfi hund ṣṣuhet i yeqqalen tenfa ayǧen.	taq_Latn
+824	travel	Eg ahanay daɣ issikallen wid issaken agent, daɣ website miɣ daɣ shop window.	taq_Latn
+1628	geography	Midden win aɣrem wan Vatican ugdan d 800 n awadem. Yeqqal akkal wan ntukken hullan ilulleten daɣ amaḍal d akkal wa-daɣ efnaẓen midden hullan.	taq_Latn
+1596	science/technology	Akayad n musnet iga Hershey d Chase, seknen-d DNA illa daɣ mantatu n awadem.	taq_Latn
+739	geography	Tigzirin tin kouk amusnet tigzirin usaɣnin d Newzealand, hanet daɣ polynesia ,deɣ ammas n aǧus n aǧariw wa idekin.	taq_Latn
+548	sports	ⴰⵙⵓⴾⵉ ⵏ ⵜⴰⵏ ⴾⵓⵥ ⴰⵔ ⵜⴰⵥⵓⵏⵉ, ⴰⵂⴰⵍ ⵢ<ⵈⵈ<ⵍ ⵢⴰⵔ ⵢ<ⵏⴼⵉ ⵂⵓⵏⴷ ⵙⵙⵓⵂ<ⵜ ⵉ ⵢ<ⵈⵈⴰⵍ<ⵏ ⵜ<ⵏⴼⴰ ⴰⵉⴶ<ⵏ.	taq_Tfng
+824	travel	<ⴴ ⴰⵂⴰⵏⴰⵢ ⴷⴰⵗ ⵉⵙⵙⵉⴾⴰⵍⵍ<ⵏ ⵡⵉⴷ ⵉⵙⵙⴰⴾ<ⵏ ⴰⴴ<ⵏⵜ, ⴷⴰⵗ ⵡ<ⴱⵙⵉⵜ< ⵎⵉⵗ ⴷⴰⵗ ⵛⵓⴱ ⵡⵉⵏⴷⵓⵡ.	taq_Tfng
+1628	geography	ⵎⵉⴷⴷ<ⵏ ⵡⵉⵏ ⴰⵗⵔ<ⵎ ⵡⴰⵏ ⴱⴰⵜⵉⵛⴰⵏ ⵓⴶⴷⴰⵏ ⴷ 800 ⵏ ⴰⵡⴰⴷ<ⵎ. ⵗ<ⵈⵈⴰⵍ ⴰⴾⴾⴰⵍ ⵡⴰⵏ ⵏⵜⵓⴾⴾ<ⵏ ⵂⵓⵍⵍⴰⵏ ⵉⵍⵓⵍⵍ<ⵜ<ⵏ ⴷⴰⵗ ⴰⵎⴰⴹⴰⵍ ⴰⴾⴾⴰⵍ ⵡⴰ-ⴷⴰⵗ <ⴼⵏⴰⵥ<ⵏ ⵎⵉⴷⴷ<ⵏ ⵂⵓⵍⵍⴰⵏ.	taq_Tfng
+1596	science/technology	ⴰⴾⴰⵢⴰⴷ ⵏ ⵎⵓⵙⵏ<ⵜ ⵉⴶⴰ ⵂ<ⵔⵛ<ⵢ ⴷ ⵛⴰⵙ, ⵙ<ⴾⵏ<ⵏ-ⴷ <ⵏⴰ ⵉⵍⵍⴰ ⴷⴰⵗ ⵎⴰⵏⵜⴰⵜⵓ ⵏ ⴰⵡⴰⴷ<ⵎ.	taq_Tfng
+739	geography	ⵟⵉⴶⵣⵉⵔⵉⵏ ⵜⵉⵏ ⴾoⵓⴾ ⴰⵎⵓⵙⵏ<ⵜ ⵜⵉⴶⵣⵉⵔⵉⵏ ⵓⵙⴰⵗⵏⵉⵏ ⴷ N<ⵡⵣ<ⴰⵍⴰⵏⴷ, ⵂⴰⵏ<ⵜ ⴷⴰⵗ ⵒoⵍⵉⵏ<ⵙⵢⴰ ,ⴷ<ⵗ ⴰⵎⵎⴰⵙ ⵏ ⴰⴶⵓⵙ ⵏ ⴰⴶⴰⵔⵉⵓ ⵡⴰ ⵉⴷ<ⴾⵉⵏ.	taq_Tfng
+548	sports	Чирек мильга йөгерүдән ярты мильгә күчкәндә, тизлек күпкә мөһимрәк була, ә чыдамлылык чикләнмәгән кирәклеккә әверелә.	tat_Cyrl
+824	travel	Веб-сайтта яки кибет витринасында агентның нинди сәфәрләрне рекламалавын карагыз.	tat_Cyrl
+1628	geography	Ватикан шәһәрендә 800 гә якын кеше яши. Бу дөньяның иң кечкенә мөстәкыйль иле һәм иң аз халыклы дәүләте.	tat_Cyrl
+1596	science/technology	Херша һәм Чейза эксперименты ДНК-ның генетик материал икәнен әйдәп баручы фаразларның берсе иде.	tat_Cyrl
+739	geography	Кук утравы - Тын океанының көнъяк ягының үзәгендә, Полинезияда урнашкан, Яңа Зеландия белән ирекле берләшүдә булган утрау-дәүләт ул.	tat_Cyrl
+548	sports	పావు మైలు నుండి అర మైలు దూరం మార్పుతో చేసే పరుగు, వేగం చాలా తక్కువ ప్రాముఖ్యతను కలిగి ఉంటుంది ఇంకా ఓర్పు అనేది ఖచ్చితంగా అవసరం అవుతుంది.	tel_Telu
+824	travel	ఏజెంట్ ఏ ట్రిప్పులను ప్రమోట్ చేస్తున్నాడో, వెబ్ సైట్ లో లేదా షాప్ విండోలో ఉన్నదా అని ఒక్కసారి చూద్దాం.	tel_Telu
+1628	geography	వాటికన్ సిటీ జనాభా సుమారు 800. ఇది ప్రపంచంలో అతి చిన్న స్వతంత్ర దేశం ఇంకా అతి తక్కువ జనాభా కలిగిన దేశం.	tel_Telu
+1596	science/technology	Hershey మరియు Chase ప్రయోగం DNA ఒక జన్యు పదార్ధం అని తెలియజేసే ప్రముఖ ప్రయోగాలలో ఒకటి.	tel_Telu
+739	geography	కుక్ దీవులు న్యూజిలాండ్ తో స్వేచ్ఛా యుత మైన సంబంధం కలిగిన ఒక ద్వీప దేశం, ఇది దక్షిణ పసిఫిక్ మహాసముద్రం మధ్యలో ఉన్న పాలినేషియాలో ఉంది.	tel_Telu
+548	sports	Бо тағйирёбӣ аз масофаи дави чоряки мил ба ними мил, суръат аҳамияти хеле камтар пайдо карда, тобоварӣ ба зарурати комил табдил меёбад.	tgk_Cyrl
+824	travel	Бубинед, ки танзимгар (агент) кадом намуди сафарҳоро, хоҳ дар вебсайт ё дар равзанаи дӯконҳо, таблиғ мекунад.	tgk_Cyrl
+1628	geography	Аҳолии Ватикан тақрибан 800 нафарро ташкил медиҳад. Он хурдтарин кишвари мустақили ҷаҳон ва кишвари дорои шумораи камтарини аҳолӣ ба шумор меравад.	tgk_Cyrl
+1596	science/technology	Санҷиши Херши ва Чейз эҳтимолоти асосие дар он бора буд, ки ДНК ин маоди генетикӣ мебошад.	tgk_Cyrl
+739	geography	Ҷазираҳои Африкаи Шарқӣ дар Уқёнуси Ҳинд дар соҳили шарқии Африка мебошанд.	tgk_Cyrl
+548	sports	Dahil sa pagbabago sa pagtakbo mula sa sangkapat hanggang sa kalahating milya, lalong hindi na gaanong nagiging importante ang bilis at ang katatagan ay nagiging lubusang pangangailangan.	tgl_Latn
+824	travel	Tingnan kung anong mga biyahe ang isinusulong ng ahente, maging sa website man o sa eskaparate.	tgl_Latn
+1628	geography	Ang populasyon ng Lungsod ng Vatican ay halos 800. Ito ang pinakamaliit na malayang bansa sa mundo at ang bansang may pinakakaunting populasyon.	tgl_Latn
+1596	science/technology	Ang eksperimento nina Hershey at Chase ay isa sa mga nangungunang mungkahi na ang DNA ay isang henetikong materyal.	tgl_Latn
+739	geography	Isang pulong bansa ang Cock Islands na may malayang ugnayan sa New Zealand, nasa Polynesia, sa gitna ng Karagatang Timog Pasipiko.	tgl_Latn
+548	sports	เมื่อเปลี่ยนจากการวิ่งระยะ 1/4 ไมล์มาเป็นแบบครึ่งไมล์ ความเร็วจะเป็นเรื่องสำคัญน้อยลงมากและความอึดจะกลายเป็นสิ่งจำเป็นอย่างยิ่งแทน	tha_Thai
+824	travel	ดูแผนท่องเที่ยวที่ตัวแทนกำลังโปรโมทจะเป็นบนเว็บไซต์หรือบนหน้าต่างร้านค้าก็ได้	tha_Thai
+1628	geography	นครวาติกันมีประชากรอยู่ราว 800 คน นับเป็นประเทศเอกราชที่เล็กที่สุดและมีประชากรน้อยที่สุดในโลก	tha_Thai
+1596	science/technology	การทดลองของเฮอร์ชีย์และเชสเป็นเบาะแสสำคัญอย่างหนึ่งที่บ่งชี้ว่าดีเอ็นเอเป็นสารพันธุกรรม	tha_Thai
+739	geography	หมู่เกาะคุก เป็นประเทศที่เป็นเกาะซึ่งมีความสัมพันธ์กับนิวซีแลนด์อย่างเสรี โดยตั้งอยู่ในโพลินีเซีย กลางมหาสมุทรแปซิฟิกใต้	tha_Thai
+548	sports	እቲ ጉያ ካብ ርብዒ ናብ ፍርቂ ማይል እንትቅየር ፍጥነት ዝነበሮ ጥቅሚ ቀኒሱን ብርታዐ ጫዋዳ ከዓ አገዳሲ ኮይኑ።	tir_Ethi
+824	travel	ብድሕረ ገፅ ይኹን ብመሸቀጢ መስኮታት እቲ ወኪል ዘፋልጦ ዘሎ ጉዕዞታት ይርኣዩ።	tir_Ethi
+1628	geography	በዝሒ ህዝቢ ከተማ ቫቲካን ኣስታት 800 እዩ። አብ ዓለምና እታ ዝናኣሰት ዓርሳ ዝኻለትን ውሑድ ህዝቢ ዘለዋን ሃገር እያ።	tir_Ethi
+1596	science/technology	ሄርሽን ቼዝን ሙከራታት ዲ ኤን ኤ ዘርኣዊ ባእታ ምዃኑ ካብ ዘረጋገጹ ሙከራታት እዮም።	tir_Ethi
+739	geography	ናይ ኩክ ደሴታት፣ ኣብ ማእኸል ውቅያኖስ ደቡብ ፓስፊክ፣ ኣብ ፓሊኔዥያ እትርከብ ምስ ኒው ዚላንድ ናፃ ርክብ ዘለዎም ናይ ደሴት ሃገራት እዮም።	tir_Ethi
+548	sports	Ol i save senis long 'quarter' i go long 'half mile run', long dispela taim spit em i no impoten na pasin bilong stap strong na go het yet em i impoten.	tpi_Latn
+824	travel	Lukluk long wanem ol raun ol 'agent' i wok long mekim promosen long en, maski em long wanpela websait o long wanpela windua bilong stoa.	tpi_Latn
+1628	geography	Populesen (population) bilong Vatican City em i kain olsem 800. Dispela em nambawan liklik kantri tru insait long wol na kantri we i gat liklik populesen tru.	tpi_Latn
+1596	science/technology	'Experiment' bilong Hershey and Chase em i wanpela bilong ol samting we i tok olsem DNA em i wanpela 'genetic material'.	tpi_Latn
+739	geography	Ol Cook Islands em ol wanpela ailan kantri long we i save wok bung wantaim New Zealand, na em i stap long Polynesa, long namel bilong South Pacific Ocean.	tpi_Latn
+548	sports	Ka phetogo ya boleele ja lobelo go tswa ko kotareng go ya ko sephatlong sa mmaele, lebelo ga le sa tlhole le nna botlhokwa thata, fa maatla le tiisetso e nna tsone konokono.	tsn_Latn
+824	travel	Lebelela go re ke mesepele efe e modiredi a e rotloetsang, e ka tswa e le mo webosaeteng kgotsa mo letlhabaphefong la lebenkele.	tsn_Latn
+1628	geography	Vatican City e na le baagi ba ka nna 800. Ke naga e nnye go gaisa e e ikemetseng mo lefatsheng, le naga e e nang le baagi ba ba kwa tlase go gaisa.	tsn_Latn
+1596	science/technology	Tekeletso ya Hershey le Chase e ne e le nngwe ya dikakantsho tse di di gogang kwa pele tsa go re DNA ke togwa ya dijini.	tsn_Latn
+739	geography	Ditlhaketlhake tsa Cook ke naga ya ditlhaketlhake tse di sa kopaneng ka gope le New Zealand, e e fitlhelwang kwa Polynesia, e e kwa bogareng jwa Borwa jwa Lewatle la Pacific.	tsn_Latn
+548	sports	Ku cinca loku vaka kona eka ku tsustuma ku suka eka kota ku ya eka hafu ya mayile, rivilo ri heleriwa hi nkoka naswona ku tiyisela swi va swa nkoka.	tso_Latn
+824	travel	Xiya leswaku u navetisa maendzo ya njhani, eka webisite kumbe efasitereni ra xitolo.	tso_Latn
+1628	geography	Vatshami vale Vatican City va kwalomu ka 800. I tiko leri tsongo leri tiyimeleke misava hinkwayo naswona ri nga na nhlayo ya le hansi ngopfu ya vanhu.	tso_Latn
+1596	science/technology	Xiringanyeto xa Hershey na Chase i xin'wana xa leswi a xi ri emahlweni leswi kombisaka leswaku DNA hi xilo xa xitekela.	tso_Latn
+739	geography	Swihlala swa Cook swi le tikweni ra swihlala naswona swi tirhisana kahle na New Zealand, leyi kumekaka ePolynesia, exikarhi ka le dzongeni wa South Pacific Ocean.	tso_Latn
+548	sports	Çärýekden ýarym mil ylgawa geçilende, tizlik has az möhüm bolýar, çydamlylyk bolsa, absolýut zerurlyga öwrülýär.	tuk_Latn
+824	travel	Websaýtda ýa-da dükanyň penjiresinde agentiň haýsy gezelençleri reklama edýändigine göz aýlaň.	tuk_Latn
+1628	geography	Watikanyň ilaty 800 adam çemesidir. Ol dünýädäki iň kiçi garaşsyz ýurt bolup, iň az ilatly ýurtdur.	tuk_Latn
+1596	science/technology	Herşi bilen Çeýziň eksperimenti DNK-nyň genetik materialdygy baradaky öňdebaryjy çaklamalaryň biri boldy.	tuk_Latn
+739	geography	Kuk adalary Günorta Ýuwaş okeanyň ortasynda Polineziýada ýerleşýän, Täze Zelandiýa bilen erkin baglanyşýan ada ýurdudyr.	tuk_Latn
+548	sports	Pala pali kusintha kwa mtunda pa zgaro za kutchimbira kufuma pa kota kufika pa hafu, cinthu cakuzirwa ni sipidi cara kweni kuzizipizga.	tum_Latn
+824	travel	Wonani dankha mtundu wa maulendo agho kampani panji munthu uyo wakuvirapo ŵanthu, kwali mpha peji la pa intaneti panji pa windo la pashopu.	tum_Latn
+1628	geography	Unandi wa wanthu mu msumba wa Vatican mphafupifupi 800. Vatican ni caru cakuyima pacekha cicoko comene caru cose capasi kweniso ni caru ico cili na ŵanthu ŵachoko comene.	tum_Latn
+1596	science/technology	Mulimo wakucita vinthu mwakuyerezgera waka uwo ukacitika na Alfred Hershey na Martha Chase ukaŵa mulimo umoza uwo ukasacizga kuti mauthenga agho ghakusangika mu maselo (DNA) ni mphepete yimoza ya majini.	tum_Latn
+739	geography	Cook Islands ni caru ca vilwa ico cili pa ubali na caru ca New Zealand ca ku Polynesia, pakati ca kumwera kwa nyaja ya Pacific.	tum_Latn
+548	sports	Çeyrek mil koşusunun yarım mil koşusuna dönüşmesiyle birlikte, hız çok daha az önemli hale geliyor ve dayanıklılık mutlak bir gereklilik haline geliyor.	tur_Latn
+824	travel	Web sitesi ya da mağaza vitrini aracılığıyla acentenin hangi gezileri ayarladığına bir göz gezdirin.	tur_Latn
+1628	geography	Vatikan'ın nüfusu 800 civarındadır. O, dünyadaki en küçük bağımsız ülkedir ve en az nüfusa sahip ülke.	tur_Latn
+1596	science/technology	The Hershey and Chase deneyi, DNA'nın genetik bir madde olduğuna dair önde gelen önerilerinden biriydi.	tur_Latn
+739	geography	Cook Adaları, Yeni Zelanda'yla serbest birliğe sahip olan, Güney Pasifik Okyanusu'nun ortasındaki Polinezya'da yer alan bir ada ülkesidir.	tur_Latn
+548	sports	Nsakrae a efiri nkyɛmu anan a aka wɔ akwansini fa mu mmirikatu no mu no, ahoɔhare bɛyɛ ade a ɛho nhia na amanehunumu boasetɔ bɛyɛ ade titiriw a ɛho hia paa.	twi_Latn
+824	travel	Hwɛ akwantu ahorow a nea ɔhwɛ akwantu so no rebɔ ho dawuro,sɛ wobɛhwɛ wɔ wɛbsaet so anaa wɔn sotɔɔ no mpoma no so.	twi_Latn
+1628	geography	Nnipa dodow a wɔwɔ Vatican City yɛ bɛyɛ 800. Ɛyɛ aman a ade wɔn ho no mu ketewa wɔ wiase na ɛyɛ ɔman a emu nnipa sua koraa.	twi_Latn
+1596	science/technology	Na Hershey ne Chase sɔhwɛ no yɛ adwenkyerɛ a edi kan no mu biako a ɛkyerɛ sɛ DNA no yɛ neama a yɛnya wɔ awo mu no mu biako.	twi_Latn
+739	geography	Cook Islands yɛ supɔw man a ɛne New Zealand ntam yɛ, a ɛwɔ Polynesia, wɔ South Pacific Ocean no mfinfini.	twi_Latn
+548	sports	ⴷ ⵙ ⵓⵙⵏⴼⵍ ⵙⴳ ⴽⴽⵓⵥ ⵖⵔ ⴰⵣⴳⵏ ⵏ ⵜⵙⵓⵔⵉⴼⵜ, ⴰⵔ ⵜⵜⵓⵖⵓⵍ ⵜⴰⵣⵣⵍⴰ ⵓⵔ ⵜⵀⵎⵎⴰ ⴱⴰⵀⵔⴰ ⵉⴳ ⵓⵥⵉⴹⵕ ⴰⵏⴱⵣⴰⵣ.	tzm_Tfng
+824	travel	ⴳⵔ ⵏⵏ ⵉⵥⵕⵉ ⵏⵏⴽ ⵖⵔ ⵜⵏⵢⵓⴷⴷⵓⵜⵉⵏ ⵏⵏⴰ ⵉⵙⵢⴰⵙⵙⴰⵏ ⵓⵙⵎⴰⴳⴰⵍ, ⴷⴳ ⵡⴰⵏⵙⴰ ⴰⵍⵉⴽⵟⵕⵓⵏⵉⵢ ⵏⵖ ⴳ ⵓⵙⵕⵥⵎ ⵏ ⵜⵣⵇⵇⴰ.	tzm_Tfng
+1628	geography	ⴰⵔ ⵉⵜⵜⴰⵡⴹ ⵡⵓⵟⵟⵓⵏ ⵏ ⵉⵎⵣⴷⴰⵖ ⵏ ⵜⵖⵔⵎⵜ ⵏ ⵍⴼⴰⵜⵉⴽⴰⵏ 800 ⵏ ⵢⴰⵏ ⵉⴳ ⵜⴰⵎⴰⵣⵉⵖⵜ ⵜⴰⵙⵉⵎⴰⵏⵜ ⴰⴽⴽⵯ ⵉⵎⵥⵥⵉⵢⵏ ⴳ ⵓⵎⴰⴹⴰⵍ ⴷ ⴳ ⴷⵔⵓⵙⵏ ⵎⵉⴷⴷⵏ.	tzm_Tfng
+1596	science/technology	ⵜⵉⵔⵎⵉⵜ ⵏ ⵀⵉⵔⵜⵛⵉ ⴷ ⵜⵛⵉⵙ ⵜⴳⴰ ⵢⴰⵜ ⵙⴳ ⵉⵙⵓⵎⵔⵏ ⵉⵣⵡⴰⵔⵏ ⵎⴰⵙ ⴷ ⴰⵙⵎⵎⴰⵎ ⴰⵖⵢⴰⵢ DNA ⴷ ⵜⴰⵎⵜⵜⴰ ⵜⴽⵓⵙⴰⵢⵜ.	tzm_Tfng
+739	geography	ⵜⵉⴳⵣⵉⵔⵉⵏ ⵏ ⴽⵓⴽ ⵉⴳⴰ ⵜⴰⵎⵓⵔⵜ ⵏ ⵜⴳⵣⵉⵔⵉⵏ ⵉⵎⵎⵣⴷⴰⵢ ⴷ ⵏⵢⵓⵣⵉⵍⴰⵏⴷⴰ, ⵢⵓⵙⴰ ⴷ ⴳ ⴱⵓⵍⵉⵏⵙⵉⴰ, ⴳ ⵡⴰⵎⵎⴰⵙ ⵏ ⵉⴼⴼⵓⵙ ⵏ ⵓⴳⴰⵔⴰⵡ ⴰⵎⵣⴳⵓ.	tzm_Tfng
+548	sports	چارەك چاقېرىمدىن يېرىم چاقىرىمغىچە يۈگۈرۈشنىڭ ئۆزگىرىشىگە ئەگىشىپ، سۈرئەت ئانچە مۇھىم بولمايدۇ، چىدامچانلىق مۇتلەق زۆرۆرىيەتكە ئايلىنىدۇ.	uig_Arab
+824	travel	مەيلى تور بېكەت ياكى دۇكان كۆزنىكىدە بولسۇن، ساياھەت كوپىراتىپلىرىنىڭ ئېلانلىرىغا قاراپ قويۇڭ.	uig_Arab
+1628	geography	ۋاتىكان شەھىرىنىڭ نوپۇسى تەخمىنەن 800 ئەتراپىدا بولۇپ، ئۇ دۇنيادىكى ئەڭ كىچىك مۇستەقىل دۆلەت، شۇنداقلا نوپۇسى ئەڭ ئاز دۆلەت ھېسابلىنىدۇ.	uig_Arab
+1596	science/technology	خىرشى ۋە چەيىس تەجرىبىسى بولسا DNA نىڭ گېن ماتېرىيالى ئىكەنلىكى توغرىسىدىكى ئاساسىي تەكلىپلەرنىڭ بىرى.	uig_Arab
+739	geography	كۇك تاقىم ئاراللىرى يېڭى زېللاندىيە بىلەن ئەركىن ھەمكارلىق ئورناتقان ئارال دۆلىتى بولۇپ، ئۇ جەنۇبىي تىنچ ئوكياننىڭ ئوتتۇرىسىدىكى پولىنېزىيەگە جايلاشقان.	uig_Arab
+548	sports	З переходом на забіги від чверті до півмилі швидкість починає відігравати значно меншу роль, натомість абсолютною необхідністю стає витривалість.	ukr_Cyrl
+824	travel	Подивіться, які подорожі рекламує посередник, або на вебсайті, або на вітрині.	ukr_Cyrl
+1628	geography	Населення Ватикану — приблизно 800 людей. Це найменша незалежна країна у світі, а також країна з найменшою кількістю населення.	ukr_Cyrl
+1596	science/technology	Експеримент Херші та Чейза став однією з основних гіпотез у питанні того, що ДНК є генетичним матеріалом.	ukr_Cyrl
+739	geography	Острови Кука — це острівна країна, що має вільну асоціацію з Новою Зеландією, розташована у Полінезії, посереднині Південного Тихого океану.	ukr_Cyrl
+548	sports	L’epongoloko lyohondo k’onepa yomilya yelupuko, okulupuka kayakwatele esilivilo lyalwa kwenda onguso yokufwima iyongwiwa calwa.	umb_Latn
+824	travel	Tala ovindekase vimõlisa usongwi welombe okasi l’okukõlisa, cikale k’osayte imwe ale k’omesa imwe.	umb_Latn
+1628	geography	Owiñgi wolupale wo-vetikanu usangiwa k’etendelo lya 800 k’omanu. Ofeka itito isangiwa volwali ikwete onguvulu kwenda ofeka l’owiñgiutito p’okati k’olofeka vikwavo.	umb_Latn
+1596	science/technology	Oku syeteka kwa Hershey kwenda Chase yakala imwe okuti o ADN yakala ocilambiwa yo citiwo.	umb_Latn
+739	geography	Alupale vyo Cook olofeka vimwe visangiwa ocipepi lo Nova Zilândia, ko Pollinésia, p’okati k’okalunga wo pacífico.	umb_Latn
+548	sports	چوتھائی سے آدھے میل کی دوڑ میں تبدیلی کے ساتھ، رفتار کی اہمیت بہت کم ہو جاتی ہے اور صبر و برداشت ایک مطلق ضرورت بن جاتی ہے۔	urd_Arab
+824	travel	اُن دوروں پر ایک نظر ڈالیں جن کی ایجنٹ تشہیر کررہا ہے، خواہ ویب سائٹ پر یا ایک دُکان کی کھڑکی میں۔	urd_Arab
+1628	geography	ویٹکن سٹی کی آبادی تقریباً 800 ہے۔ یہ دینا کا سب سے چھوٹا آزاد ملک ہے جس کی آبادی کمترین ہے۔	urd_Arab
+1596	science/technology	ڈی این اے کو جینیاتی مادہ بتانے کے تعلق سے ہرشی اور چیس کا تجربہ سب سے اہم تھا۔	urd_Arab
+739	geography	جنوبی بحرالکاہل کے وسط میں پالی نیشیا میں واقع کوک جزیرے نیوزی لینڈ کے ساتھ آزادانہ وابستگی والے جزیروں والا ملک ہے-	urd_Arab
+548	sports	Chorak mil yugurishdan yarim mil yugurishga otilganida tezlikning ahamiyatini ancha kamayadi va bardoshlilik mutlaq zaruriyatga aylanadi.	uzn_Latn
+824	travel	Xoh veb-sayt, xoh do'kon peshtaxtasida bo'lsin, agent qanday sayohatlarni reklama qilayotganini ko'rib chiqing.	uzn_Latn
+1628	geography	Vatikan shahri aholisi 800 kishi atrofida. U dunyodagi eng kichik mustaqil davlat va eng kam aholiga ega mamlakatdir.	uzn_Latn
+1596	science/technology	DNK genetik material ekanligi Xershey va Cheyz tajribasining asosiy taxminlaridan biri edi.	uzn_Latn
+739	geography	Kuk orollari Janubiy Tinch okeani o'rtasida, Polineziyada joylashgan bo'lib, Yangi Zelandiya bilan erkin birlashmadagi orol davlatdir.	uzn_Latn
+548	sports	Col pasajo dal quarto al mèso miglio, la vełocità deventa tant manco inportante e la resistensa deventa ‘na necesità assołuta.	vec_Latn
+824	travel	Daghe na ociada a quałi viaji che l’agente el promove, sia sul sito sia suła vetrina.	vec_Latn
+1628	geography	La popołasion dea Cità del Vaticàn xe de circa 800 persone. Xe el pì picoło paese indipendente del mondo e el paese co manco abitanti.	vec_Latn
+1596	science/technology	L’esperimento de Hershey e Chase xe stà uno dei sugerimenti principài che el DNA gera fatto de materiałe genetico.	vec_Latn
+739	geography	Łe isołe Cook łe xe un stato insułare in asociasión libera co a Nova Zelanda. El se trova in Połinesia, nel mexo de l’Oceano Pacifico.	vec_Latn
+548	sports	Với sự thay đổi từ 1/4 sang 1/2 dặm chạy, tốc độ trở nên ít quan trọng hơn nhiều và sức bền trở thành điều kiện tiên quyết.	vie_Latn
+824	travel	Hãy xem những chuyến du lịch nào mà đại lý đang khuyến mãi: dù là bạn xem trên website hay qua quảng cáo tại đại lý.	vie_Latn
+1628	geography	Dân số của thành phố Vatican khoảng 800 người. Đây là quốc gia độc lập nhỏ nhất trên thế giới và là quốc gia có dân số ít nhất.	vie_Latn
+1596	science/technology	Thí nghiệm của Hershey và Chase là một trong những dẫn chứng thuyết phục cho thấy DNA là một loại vật liệu gen.	vie_Latn
+739	geography	Quần Đảo Cook là một quốc đảo được tự do liên kết với New Zealand, tọa lạc tại Polynesia, ở giữa biển Nam Thái Bình Dương.	vie_Latn
+548	sports	Ha pagbag-o tikang ha quarter ngadto ha katunga nga milya han pagdalagan, an kalaksihon nagigin mas diri importante ngan an pagpailob nagigin usa nga labi nga kinahanglan.	war_Latn
+824	travel	Kitaa kon ano nga mga biyahe an gin-aaghat han ahente, bisan kon ha usa nga website man o ha usa nga bintana han tindahan.	war_Latn
+1628	geography	Maabot ha 800 an populasyon ha Siyudad han Vatican. Amu ini an pinakagutiay nga independente nga nasud ha kalibotan ngan an nasud nga may-ada pinakahamubo nga populasyon.	war_Latn
+1596	science/technology	An eksperimento han Hershey ngan Chase usa ha mga nangunguna nga suhestiyon nga an DNA usa nga genetiko nga materyal.	war_Latn
+739	geography	An Cook Islands usa nga isla nga nasud nga may-ada libre nga pakig-upod ha New Zealand, nga nahamumutang ha Polynesia, ha butnga han South Pacific Ocean.	war_Latn
+548	sports	Bimu jaaree ci xaaju-genwall bi dem ci genwall, gaawaay bi amatul solo lool te yaggaay bi dafay mujj doon lu mënul ñakk.	wol_Latn
+824	travel	Xoolal li tukki liggéeykat bi nekk di siiwal, mu doon ci ab daluweb wala ci ab palanteer bu ndàw.	wol_Latn
+1628	geography	Dëkk vatican amna lu toollci juróom ñetfukk téemeer ci ay nit. Mooy dëkk bi gënna tuuti bi moom boppam ak nit ñu tuuti ci Àdduna.	wol_Latn
+1596	science/technology	Jaar-jaaru Hershey ak Chase nekk na benn ci digle yu gëna am solo ni ADN nekkoon na matariyeel buy dundu.	wol_Latn
+739	geography	Cook Island yi ay kembaari dunyi nekk ci mbooloo bu laajul dara ak wa Nuwel Seland la, nekk ci Polinesi, ci diggu Géeju Pacfik bu ci bët Saalum.	wol_Latn
+548	sports	Ngotshintsho lokubaleka ihafu usuka kwi kota yemayile, isantya siya singabaluleki kangako kwaye unyamezelo lusesona sidingo.	xho_Latn
+824	travel	Jonga ukuba loluphi uhambo olukhuthazwa yiarhente, nokuba ikwiwebhusayithi okanye kwifestile yevenkile.	xho_Latn
+1628	geography	Inginginya yesixeko iVatican City iku-800. Ilelona lizwe lincinci elizimeleyo ehlabathini nelibantu abambalwa.	xho_Latn
+1596	science/technology	Uvavanyo lweHershey kunye noChase yenye yeengcebiso eziphambili zokuba iDNA yayiyinto yemfuza.	xho_Latn
+739	geography	Iziqithi zase-Cook lilizwe leziqithi elimanyane ngokukhululekileyo ne-New Zealan, ese-Polynesia, esiphakathini ku-Mzantsi Wolwandle le-Pacific.	xho_Latn
+548	sports	מיט די טויש פון די פערטל צו די האלב מייל לויף, ווערט שנעלקייט אסאך ווייניגער וויכטיג און ווידערשטאנד ווערט א גענצליכע נויטיגקייט.	ydd_Hebr
+824	travel	גיבט א קוק אויף וועלכע רייזעס דער אגענט שטיצט, צי אויף א וועבסייט אדער אין א פענסטער פון א געשעפט.	ydd_Hebr
+1628	geography	וואטיקאן סיטי'ס באפעלקערונג איז אומגעפער 800. עס איז די קלענסטע זעבסטשטענדיגע לאנד אין דער וועלט און דער לאנד מיט די נידריגסטע באפעלקערונג.	ydd_Hebr
+1596	science/technology	די הערשי און טשעיס פראויבע איז געווען איינער פון די עיקר פארשלאגן אז DNA איז גענעטישע מאטריאל.	ydd_Hebr
+739	geography	די קוק אינזלען זענען אן אינזל לאנד אין פרייע אסאסיאציע מיט ניו זילענד, געפונען אין פאלינעזיע, אין מיטן פון די דרום פאסיפישע ים.	ydd_Hebr
+548	sports	Pẹ̀lú àyípadà eré sísá láti ìdámẹ́ta sí ìdá méjì máìlì, yíyára dí ohun tí kò fi bẹ́ẹ̀ wúlò lọ́pọ̀ tí ìfaradà sì di dandan.	yor_Latn
+824	travel	Ṣe àgbéyẹ̀wò àwọn ìrìnàjò tí awọn olùpolówó ọjà ń se àgbélárugẹ, yálà ní orí ìtàkùn àgbáyé ni tàbí ní ojú fèrèsè ilé ìtajà.	yor_Latn
+1628	geography	Àwọn èrò ìlú Vatican tó bí i ẹgbẹ̀rin. ó jẹ́ ìlú olómìnira kékeré kan lágbàláayé àti orílèèdè tó ní èrò tó kéré jù.	yor_Latn
+1596	science/technology	Idanwo Esi ati Saasi je ikan ninu awon aba wipe DNA je nkan jenetiki, to siwaju ju.	yor_Latn
+739	geography	Cook Island jẹ island orílẹ́ èdè tó wà ní ẹgbẹ́ ọ̀fẹ́ pẹ̀lú ìlú New Zealand, tó wà ní Polynesia, ní àárín South Pacific Ocean.	yor_Latn
+548	sports	從四分一英里跑轉為半英里跑時，速度的重要性減少，而耐力則變得絕對必要。	yue_Hant
+824	travel	看看旅行社正在推廣的旅程，無論是在網站上還是在門店櫥窗。	yue_Hant
+1628	geography	梵蒂岡城的人口約八百人。它是世界上面積最小和人口最少的獨立國家。	yue_Hant
+1596	science/technology	赫希和蔡斯的實驗是其中一個重要的提議，認為DNA是遺傳物質。	yue_Hant
+739	geography	庫克群島(Cook Islands)是一個島國，位於南太平洋中部的波里尼西亞(Polynesia)，並與紐西蘭自由結盟。	yue_Hant
+548	sports	从四分之一英里转变为半英里的赛跑，速度变得不那么重要了，耐力成为绝对重要的因素。	zho_Hans
+824	travel	看看旅行社推广什么旅游产品，可以在网站上或商店橱窗里查看。	zho_Hans
+1628	geography	梵蒂冈城的人口大约有 800 人。它是世界上最小的独立国家，也是人口最少的国家。	zho_Hans
+1596	science/technology	赫希及崔斯（Hershey and Chase）的实验，是说明 DNA 是遗传物质的主要迹象依据之一。	zho_Hans
+739	geography	库克群岛是一个岛国，是新西兰的自由结合区，位于南太平洋中部的波利尼西亚。	zho_Hans
+548	sports	由於跑步距離從四分之一英里改為半英里，速度的重要性變得越來越低，耐力變成為絕對必要的條件。	zho_Hant
+824	travel	你可以在網站或商店展示區看到旅行社推廣的行程。	zho_Hant
+1628	geography	梵蒂岡的人口為八百人左右，是全世界最小的獨立國家，也是人口最少的國家。	zho_Hant
+1596	science/technology	赫雪-蔡司實驗是顯示 DNA 為遺傳物質的主要實驗之一。	zho_Hant
+739	geography	庫克群島是一個與紐西蘭自由結盟的島國，位於南太平洋中部的玻里尼西亞。	zho_Hant
+548	sports	Dengan perubahan daripada larian suku batu ke larian setengah batu, kelajuan menjadi kurang penting dan daya tahan menjadi keperluan mutlak.	zsm_Latn
+824	travel	Lihat jenis perjalanan yang dipromosi ejen tersebut, sama ada pada laman web atau jendela kedai.	zsm_Latn
+1628	geography	Penduduk Vatican City adalah sekitar 800. Ia adalah negara bebas yang paling kecil di dunia dan negara dengan penduduk yang paling rendah.	zsm_Latn
+1596	science/technology	Eksperimen Hershey dan Chase merupakan salah satu daripada cadangan utama bahawa DNA merupakan bahan genetik.	zsm_Latn
+739	geography	Kepulauan Cook merupakan negara pulau dengan hubungan bebas dengan New Zealand, terletak di Polynesia, di tengah Laut Pasifik Selatan.	zsm_Latn
+548	sports	Ngoshintsho kusuka engxenyeni yesine kuye engxenyeni yokusubatha kwemayela, isivinini siba esingabalulekile kakhulu futhi ukukhuthazela kuba isidingo ngokuphelele.	zul_Latn
+824	travel	Buka ukuthi inkampani ikhangisa ngaluphi uhambo, kungaba kuyiwebhusayithi noma efasiteleni lesitolo.	zul_Latn
+1628	geography	Abantu beDolobha lase-Vatican bacishe babe ngu-800. Izwe elizimele elincane kunalo wonke emhlabeni nezwe elinabantu abancane kunabo bonke.	zul_Latn
+1596	science/technology	Isilingo sika-Hershey no-Chase bekungokunye kokusikisela okuhamba phampili kokuthi iDNA isakhi sofuzo.	zul_Latn
+739	geography	Iziqhingi zoMpheki isiqhingi esiyizwe elizihlanganise ngokuzithandela neNyuzilandi, ezisePholinesiya, phakathi Nolwandlekazi iNingizimu Phasifiki.	zul_Latn

--- a/tests/pixel_renderer/test_backward_compatibility.py
+++ b/tests/pixel_renderer/test_backward_compatibility.py
@@ -1,0 +1,128 @@
+import csv
+import os
+
+import pytest
+from PIL import Image, ImageChops
+
+from font_download import FontConfig
+from font_download.example_fonts.noto_sans import FONTS_NOTO_SANS
+from pixel_renderer import PixelRendererProcessor
+
+# ---------------------------
+#  Fixtures
+# ---------------------------
+
+
+@pytest.fixture(scope="session")
+def sample_images_dir():
+    """
+    Directory that contains {lang}.png reference images and samples.tsv.
+    Taken from the SAMPLE_IMAGES_DIR environment variable.
+    If unset, all tests will be skipped.
+    """
+    path = os.environ.get("SAMPLE_IMAGES_DIR")
+    if not path:
+        pytest.skip("Environment variable SAMPLE_IMAGES_DIR not set — skipping visual tests")
+    if not os.path.exists(path):
+        pytest.skip(f"SAMPLE_IMAGES_DIR path not found: {path}")
+    return path
+
+
+# ---------------------------
+#  Utility helpers
+# ---------------------------
+
+
+def read_tsv(tsv_path):
+    with open(tsv_path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        return list(reader)
+
+
+def group_by_language(rows):
+    grouped = {}
+    for row in rows:
+        lang = row["language"]
+        grouped.setdefault(lang, []).append(row)
+    return grouped
+
+
+def render_language_image(lang, examples, pixel_processor):
+    """Render and concatenate text examples for one language."""
+    examples_sorted = sorted(examples, key=lambda x: int(x["index_id"]))
+    rendered_images = []
+
+    for ex in examples_sorted:
+        text = ex.get("text", "").strip()
+        if not text:
+            continue
+        img = pixel_processor.render_text_image(text)
+        rendered_images.append(img)
+
+    if not rendered_images:
+        pytest.skip(f"No valid examples for {lang}")
+
+    widths = [im.width for im in rendered_images]
+    heights = [im.height for im in rendered_images]
+    total_height = sum(heights)
+    max_width = max(widths)
+
+    combined = Image.new("RGBA", (max_width, total_height), (255, 255, 255, 0))
+    y_offset = 0
+    for im in rendered_images:
+        combined.paste(im, (0, y_offset))
+        y_offset += im.height
+
+    return combined
+
+
+def images_are_equal(img1, img2):
+    """Compare two images pixel-by-pixel."""
+    if img1.size != img2.size:
+        return False
+    diff = ImageChops.difference(img1, img2)
+    return diff.getbbox() is None
+
+
+# ---------------------------
+#  Dynamic test generation
+# ---------------------------
+
+
+def pytest_generate_tests(metafunc):
+    """Dynamically create one test per language if SAMPLE_IMAGES_DIR is set."""
+    if "language_case" in metafunc.fixturenames:
+        base_dir = os.environ.get("SAMPLE_IMAGES_DIR")
+        if not base_dir or not os.path.exists(base_dir):
+            metafunc.parametrize("language_case", [])
+            return
+
+        tsv_path = os.path.join(base_dir, "samples.tsv")
+        if not os.path.exists(tsv_path):
+            pytest.skip(f"No samples.tsv found in {base_dir}")
+
+        rows = read_tsv(tsv_path)
+        grouped = group_by_language(rows)
+        cases = [(lang, examples) for lang, examples in grouped.items()]
+        metafunc.parametrize("language_case", cases, ids=[c[0] for c in cases])
+
+
+# ---------------------------
+#  Tests
+# ---------------------------
+
+
+def test_render_matches_reference(language_case, sample_images_dir):
+    """Compare re-rendered language images with reference ones."""
+    lang, examples = language_case
+    reference_path = os.path.join(sample_images_dir, f"{lang}.png")
+    if not os.path.exists(reference_path):
+        pytest.skip(f"Reference image missing: {reference_path}")
+
+    font_config = FontConfig(sources=FONTS_NOTO_SANS)
+    pixel_processor = PixelRendererProcessor(font=font_config)
+
+    rendered_img = render_language_image(lang, examples, pixel_processor)
+    ref_img = Image.open(reference_path).convert("RGBA")
+
+    assert images_are_equal(rendered_img, ref_img), f"Rendered image differs from reference for {lang}"


### PR DESCRIPTION
This is related to #2, and it should fix the issue also as well. This PR implements backward compatibility tests for the renderer. There are 3 new files,

- `examples/pixel_renderer/samples.tsv` contains example sentences from [SIB-200](https://aclanthology.org/2024.eacl-long.14/). This file includes 5 examples per language, covering all 200 langauges present in the SIB-200 benchmark.
- `examples/pixel_renderer/create_sample_images.py`: This script reads the `samples.tsv` (via `--input-file` option) and produces sample rendered text images per language at the specified `--output-dir`, using the provided set of example sentences. So, instead of saving all images individually, this script groups examples by language, concatenates visually rendered sentences vertically, and produces one image file per language (e.g. `eng_Latn.png`). It copies the `samples.tsv` file into this directory, and additionally creates a JSON file `versions.json` which contains the current versions of related packages (e.g. `pango`, `pygobject`).
- `tests/pixel_renderer/test_backward_compatibility.py`: This is the main test file. It takes the sample image directory path via the environment variable `SAMPLE_IMAGES_DIR`. I don't know whether there exists a more viable solution to pass command line arguments using `pytest`.

`ruff check` does not create any warning/error for these new files. I used AI tools to implement tests where I reviewed the code accordingly in detail. I was not completely sure about where I should have put `samples.tsv` and `create_sample_images.py` files. We can also move these files to somewhere else. Also, if there is better way to pass the sample image dir value other than environment variable, let's follow that approach. Lastly, this PR is **not ready** for merge, because I need to write some documentation about it.